### PR TITLE
fix: 상품 업로드 중 오류 시 성공했다고 뜨는 이슈 수정

### DIFF
--- a/app/routes/admin/product-manage.tsx
+++ b/app/routes/admin/product-manage.tsx
@@ -816,28 +816,28 @@ const schema = [
     column: "이미지등록(상세)",
     type: String,
     value: (item: LoadedProduct) =>
-      makeFileName(item.id, undefined, item.mainImageName.split('.').pop() ?? ".jpg","main"),
+      `big/${makeFileName(item.id, undefined, item.mainImageName.split('.').pop() ?? ".jpg","main")}`,
     width: 20,
   },
   {
     column: "이미지등록(목록)",
     type: String,
     value: (item: LoadedProduct) =>
-      makeFileName(item.id, undefined, item.mainImageName.split('.').pop() ?? ".jpg", "main"),
+    `big/${makeFileName(item.id, undefined, item.mainImageName.split('.').pop() ?? ".jpg", "main")}`,
     width: 20,
   },
   {
     column: "이미지등록(작은목록)",
     type: String,
     value: (item: LoadedProduct) =>
-      makeFileName(item.id, undefined, item.mainImageName.split('.').pop() ?? ".jpg", "main"),
+    `big/${makeFileName(item.id, undefined, item.mainImageName.split('.').pop() ?? ".jpg", "main")}`,
     width: 20,
   },
   {
     column: "이미지등록(축소)",
     type: String,
     value: (item: LoadedProduct) =>
-      makeFileName(item.id, undefined, item.thumbnailImageName.split('.').pop() ?? ".jpg", "thumbnail"),
+    `big/${makeFileName(item.id, undefined, item.thumbnailImageName.split('.').pop() ?? ".jpg", "thumbnail")}`,
     width: 20,
   },
   {
@@ -846,7 +846,7 @@ const schema = [
     value: (item: LoadedProduct) => {
       let str = "";
       for (let i = 0; i < item.detailImageNameList.length; i++) {
-        str += makeFileName(item.id, i, item.detailImageNameList[i].split('.').pop() ?? ".jpg", "detail");
+        str += `big/${makeFileName(item.id, i, item.detailImageNameList[i].split('.').pop() ?? ".jpg", "detail")}`;
         if (i < item.detailImageNameList.length - 1) {
           str += "|";
         }

--- a/app/routes/partner/product-manage.tsx
+++ b/app/routes/partner/product-manage.tsx
@@ -158,6 +158,7 @@ export const action: ActionFunction = async ({ request }) => {
       if (result == null) {
         return {
           isWaiting: true,
+          isStartWaiting: true,
           progress: 0,
           status: "ok",
         };
@@ -620,6 +621,9 @@ export default function PartnerProductManage() {
   //결과로 오는 거 바탕으로 안내모달
   useEffect(() => {
     if (actionData !== undefined && actionData !== null) {
+      if(actionData.isStartWaiting){
+        setIsUploadInProgress(true);
+      }
       if (actionData.isWaiting) {
         setImageUploadProgress(actionData.progress);
         console.log("isWaiting status: ", actionData.status);
@@ -1132,7 +1136,6 @@ export default function PartnerProductManage() {
                 if (checkRequirements()) {
                   setIsLoading(true);
                   await submitProduct();
-                  setIsUploadInProgress(true);
                   setIsLoading(false);
                 }
               }}


### PR DESCRIPTION
- 오류 여부에 관계 없이 바로 업로드대기상태로 들어가서, 오류때문에 업로드를 실패하고 대기상태를 종료하면 성공창이 뜨는 현상이 존재했는데, 오류가 없어야 업로드대기상태로 들어가서 오류가 떠도 성공창이 뜨지 않도록 수정