### PR TITLE
fix: 개별메일전송 임시 개수 제한

### DIFF
--- a/app/routes/admin/settlement-manage.tsx
+++ b/app/routes/admin/settlement-manage.tsx
@@ -189,7 +189,12 @@ export default function AdminSettlementManage() {
   async function sendEmail() {
     const selectedPartners = updateCheckedItems();
     if (selectedPartners.length > 0) {
-      setIsSendEmailConfirmModalOpened(true);
+      if(selectedPartners.length <= 2){ 
+        setIsSendEmailConfirmModalOpened(true);
+      } else {
+        setNoticeModalStr("현재는 한 번에 최대 2통의 메일을 보낼 수 있습니다.");
+        setIsNoticeModalOpened(true);
+      }
     } else {
       setNoticeModalStr("선택된 파트너가 없습니다.");
       setIsNoticeModalOpened(true);


### PR DESCRIPTION
Resend 정책 상 1초 당 메일을 최대 2개까지만 전송 가능. 

임시로 한 번에 두 파트너까지만 메일 전송 요청을 보낼 수 있게 하고, 2개 이상 선택 시 메일 못보내도록 설정.