### PR TITLE
fix: 정산내역 공유를 다수에게 메일 보낼 수 있게 다시 조정

### DIFF
--- a/app/routes/admin/settlement-manage.tsx
+++ b/app/routes/admin/settlement-manage.tsx
@@ -218,37 +218,7 @@ export default function AdminSettlementManage() {
 
   //안내메일 전송 요청을 post합니다.
   function submitSendEmail(partnerList: string[]) {
-    const temp = [
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-      "김태정 테스트계정",
-    ];
-    const data = JSON.stringify(temp);
+    const data = JSON.stringify(partnerList);
     const formData = new FormData(formRef.current ?? undefined);
     formData.set("partners", data);
     formData.set("action", "send-email");
@@ -295,7 +265,7 @@ export default function AdminSettlementManage() {
           }}
         >
           {`선택된 파트너 ${selectedPartners.length}곳에 안내 메일을 전송하시겠습니까?
-          (10곳 당 약 2초 소요)`}
+          (건당 약 0.5초 소요)`}
           <div style={{ height: "20px" }} />
           <div style={{ display: "flex", justifyContent: "center" }}>
             <ModalButton

--- a/app/routes/admin/settlement-manage.tsx
+++ b/app/routes/admin/settlement-manage.tsx
@@ -76,7 +76,7 @@ export const action: ActionFunction = async ({ request }) => {
           message: `${result.partnerName}에게 메일 전송 중에 오류가 발생했습니다.\n${result.message}`,
         };
       } else {
-        return { status: "ok", message: "메일 전송을 완료하였습니다." };
+        return { status: "ok", message: result.message };
       }
       break;
   }
@@ -189,12 +189,7 @@ export default function AdminSettlementManage() {
   async function sendEmail() {
     const selectedPartners = updateCheckedItems();
     if (selectedPartners.length > 0) {
-      if(selectedPartners.length <= 2){ 
-        setIsSendEmailConfirmModalOpened(true);
-      } else {
-        setNoticeModalStr("현재는 한 번에 최대 2통의 메일을 보낼 수 있습니다.");
-        setIsNoticeModalOpened(true);
-      }
+      setIsSendEmailConfirmModalOpened(true);
     } else {
       setNoticeModalStr("선택된 파트너가 없습니다.");
       setIsNoticeModalOpened(true);
@@ -223,7 +218,37 @@ export default function AdminSettlementManage() {
 
   //안내메일 전송 요청을 post합니다.
   function submitSendEmail(partnerList: string[]) {
-    const data = JSON.stringify(partnerList);
+    const temp = [
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+      "김태정 테스트계정",
+    ];
+    const data = JSON.stringify(temp);
     const formData = new FormData(formRef.current ?? undefined);
     formData.set("partners", data);
     formData.set("action", "send-email");
@@ -232,7 +257,7 @@ export default function AdminSettlementManage() {
 
   return (
     <PageLayout>
-      <LoadingOverlay visible={navigation.state == "loading"} overlayBlur={2} />
+      <LoadingOverlay visible={navigation.state == "loading" || navigation.state == "submitting"} overlayBlur={2} />
 
       {/* 안내용 모달 */}
       <BasicModal
@@ -244,7 +269,7 @@ export default function AdminSettlementManage() {
             justifyContent: "center",
             textAlign: "center",
             fontWeight: "700",
-            whiteSpace: "pre-line"
+            whiteSpace: "pre-line",
           }}
         >
           {noticeModalStr}
@@ -269,7 +294,8 @@ export default function AdminSettlementManage() {
             fontWeight: "700",
           }}
         >
-          {`선택된 파트너 ${selectedPartners.length}곳에 안내 메일을 전송하시겠습니까?`}
+          {`선택된 파트너 ${selectedPartners.length}곳에 안내 메일을 전송하시겠습니까?
+          (10곳 당 약 2초 소요)`}
           <div style={{ height: "20px" }} />
           <div style={{ display: "flex", justifyContent: "center" }}>
             <ModalButton

--- a/app/services/resend.server.ts
+++ b/app/services/resend.server.ts
@@ -3,6 +3,7 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_KEY);
 
+
 export async function sendResendEmail({
   to,
   subject,
@@ -13,11 +14,17 @@ export async function sendResendEmail({
   html: string;
 }) {
   const result = await resend.emails.send({
-    from: "kyj@tabacpress.xyz",
+    from: "tabacpress<kyj@tabacpress.xyz>",
     to: to,
     subject: subject,
     html: html,
   });
 
+  return result;
+}
+
+//mailList: {from: string; to: string[]; subject: string; html: string;}
+export async function sendResendBatchEmail({ mailList }: { mailList: any[] }) {
+  const result = await resend.batch.send(mailList);
   return result;
 }


### PR DESCRIPTION
- 기존에 rate limit 때문에 한 번에 두 명에게만 보낼 수 있던 메일 한도를 다시 풀었습니다. 
- 메일 발송시, 발송자가 tabacpress<kyj@tabacpress.xyz>로 보이게 하였습니다. 