### PR TITLE
feature: 수신함/발신함에서 어드민도 회신 가능 + 공유 후 삭제 가능

### DIFF
--- a/app/components/notice.tsx
+++ b/app/components/notice.tsx
@@ -186,7 +186,7 @@ export function AdminNotice({
           }}
         >
           해당 알림을 공유하시겠십니까? <br />
-          공유한 알림은 수정하거나 삭제할 수 없습니다.
+          공유한 알림은 수정할 수 없습니다.
           <div style={{ height: "20px" }} />
           <div style={{ display: "flex", justifyContent: "center" }}>
             <ModalButton onClick={() => setIsShareModalOpened(false)}>
@@ -332,7 +332,18 @@ export function AdminNotice({
               />{" "}
             </div>
           ) : (
-            <></>
+            <div style={{ display: "flex" }}>
+              <img
+                src={"/images/icon_trash.svg"}
+                onClick={() => setIsDeleteModalOpened(true)}
+                style={{
+                  width: "30px",
+                  height: "30px",
+                  marginRight: "10px",
+                  cursor: "pointer",
+                }}
+              />
+            </div>
           )}
         </div>
         <NoticeGridContainer>
@@ -374,13 +385,38 @@ export function AdminNotice({
               </div>
               <div style={{ width: "calc(100% - 120px)" }}>
                 {noticeItem.replies.map((reply: string, index: number) => {
-                  return <div style={{ padding: "13px", whiteSpace: "pre-line" }}>{reply}</div>;
+                  return (
+                    <div
+                      style={{ padding: "13px", whiteSpace: "pre-line" }}
+                      key={`Reply_${index}`}
+                    >
+                      {reply}
+                    </div>
+                  );
                 })}
               </div>
             </NoticeGridItem>
           ) : (
             <></>
           )}
+          <NoticeGridItem
+            style={{ gridColumnStart: "span 2" }}
+          >
+            <Form method="post" style={{display: "flex", width: "100%"}} id="reply-form">
+              <ReplyInputBox name={"reply"} />
+              <input type="hidden" value={"reply"} name="action" required />
+              <input
+                type="hidden"
+                value={noticeItem.docId}
+                name="id"
+                required
+              />
+              <input type="hidden" value={monthStr} name="month" required />
+              <BlackButton style={{ fontSize: "16px" }} type="submit">
+                {"메세지 추가"}
+              </BlackButton>
+            </Form>
+          </NoticeGridItem>
         </NoticeGridContainer>
       </NoticeBox>
       {noticeItem.replies.length == 0 && noticeItem.sharedDate != undefined ? (

--- a/app/routes/admin/alert.tsx
+++ b/app/routes/admin/alert.tsx
@@ -25,6 +25,8 @@ import {
   editNotice,
   getNotices,
   getPartnerProfile,
+  isAdmin,
+  replyNotice,
   shareNotice,
 } from "~/services/firebase.server";
 
@@ -219,6 +221,34 @@ export const action: ActionFunction = async ({ request }) => {
         });
       }
     }
+  } else if (actionType == "reply") {
+    const id = body.get("id")?.toString();
+    const month = body.get("month")?.toString();
+    const reply = body.get("reply")?.toString();
+    if (
+      id !== undefined &&
+      month !== undefined &&
+      reply !== undefined &&
+      reply.length > 0
+    ) {
+      const result = await replyNotice({
+        monthStr: month,
+        id: id,
+        reply: reply,
+        isAdmin: true,
+      });
+      if (result == true) {
+        return json({ message: `추가 메세지 전송이 완료되었습니다.` });
+      } else {
+        return json({
+          message: `메세지 전송 과정 중 문제가 발생했습니다.${"\n"}${result}`,
+        });
+      }
+    } else {
+      return json({
+        message: `메세지 내용이 잘못되었습니다. 다시 시도해주세요.`,
+      });
+    }
   }
   return null;
 };
@@ -277,7 +307,12 @@ export default function AdminAlert() {
 
   return (
     <>
-      <LoadingOverlay visible={navigation.state == "loading"} overlayBlur={2} />
+      <LoadingOverlay
+        visible={
+          navigation.state == "loading" || navigation.state == "submitting"
+        }
+        overlayBlur={2}
+      />
       {/* 안내용 모달 */}
       <BasicModal
         opened={isNoticeModalOpened}
@@ -370,7 +405,7 @@ export default function AdminAlert() {
         </div>
       </BasicModal>
 
-      <PageLayout style={{display: "block"}}>
+      <PageLayout style={{ display: "block" }}>
         <div
           style={{
             display: "flex",

--- a/app/routes/partner/alert.tsx
+++ b/app/routes/partner/alert.tsx
@@ -73,6 +73,7 @@ export const action: ActionFunction = async ({ request }) => {
         monthStr: month,
         id: id,
         reply: reply,
+        isAdmin: false
       });
       if (result == true) {
         return json({ message: `답신이 완료되었습니다.` });
@@ -86,7 +87,7 @@ export const action: ActionFunction = async ({ request }) => {
   return null;
 };
 
-export default function AdminAlert() {
+export default function PartnerAlert() {
   const [selectedDate, setSelectedDate] = useState<Date>(); // 선택중인 날짜 (현재 조회된 월이 아닌, MonthSelectPopover로 선택중인 날짜)
   const [selectedMonthStr, setSelectedMonthStr] = useState<string>(); //선택중인 날짜의 string (XX년 XX월)
   const [partnerName, setPartnerName] = useState<string>(""); //파트너명 (조회된 파트너명으로 시작, 입력창으로 수정 및 조회)
@@ -95,10 +96,8 @@ export default function AdminAlert() {
   const [isNoticeModalOpened, setIsNoticeModalOpened] =
     useState<boolean>(false);
 
-  const formRef = useRef<HTMLFormElement>(null);
   const loaderData = useLoaderData();
   const actionData = useActionData();
-  const submit = useSubmit();
   const navigation = useNavigation();
 
   useEffect(() => {

--- a/app/services/firebase.server.ts
+++ b/app/services/firebase.server.ts
@@ -1451,7 +1451,7 @@ export async function replyNotice({
 }) {
   try {
     const time = getTimezoneDate(new Date());
-    const dateStr = dateToDayStr(time);
+    const dateStr = dateToDayStr(new Date());
     const timeStr = `${dateStr} ${time.getHours()}:${String(time.getMinutes()).padStart(2, "0")}`;
     const replyStr = `${isAdmin ? "(어드민)" : "(파트너)"}[${timeStr}]
     ${reply}`;

--- a/app/services/firebase.server.ts
+++ b/app/services/firebase.server.ts
@@ -1442,16 +1442,18 @@ export async function replyNotice({
   monthStr,
   id,
   reply,
+  isAdmin
 }: {
   monthStr: string;
   id: string;
   reply: string;
+  isAdmin: boolean
 }) {
   try {
     const time = getTimezoneDate(new Date());
     const dateStr = dateToDayStr(time);
     const timeStr = `${dateStr} ${time.getHours()}:${String(time.getMinutes()).padStart(2, "0")}`;
-    const replyStr = `[${timeStr}]
+    const replyStr = `${isAdmin ? "(어드민)" : "(파트너)"}[${timeStr}]
     ${reply}`;
     await updateDoc(doc(firestore, `notices/${monthStr}/items/${id}`), {
       replies: arrayUnion(replyStr),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/82e06ce2-5a96-496f-b5a3-08c6b73caaf2)
![image](https://github.com/user-attachments/assets/10e39a01-dd6f-4b80-bc17-e92609bcdd19)

- 어드민이 공지 공유 후 파트너 답신 확인만 가능하고 추가 메세지 전달이 불가능했으나, 이제 파트너와 마찬가지로 추가메세지 남길 수 있음
- 어드민이 공지 공유 후 메시지 삭제 가능