### PR TITLE
hotfix: settlement sum error if partner does not exist anymore

### DIFF
--- a/app/components/settlement_sum.tsx
+++ b/app/components/settlement_sum.tsx
@@ -8,8 +8,8 @@ import { isMobile } from "~/utils/mobile";
 export type SettlementSumItem = {
   partnerName: string;
   data: any;
-  brn: string;
-  bankAccount: string;
+  brn?: string;
+  bankAccount?: string;
   businessName?: string;
   businessTaxStandard?: string;
 };

--- a/app/services/firebase.server.ts
+++ b/app/services/firebase.server.ts
@@ -419,11 +419,11 @@ export async function getAllSettlementSum({ monthStr }: { monthStr: string }) {
     let bankAccount = "";
     let businessName = "";
     let businessTaxStandard = "";
-    if (partnerProfile !== null) {
-      brn = partnerProfile.brn;
-      bankAccount = partnerProfile.bankAccount;
-      businessName = partnerProfile.businessName;
-      businessTaxStandard = partnerProfile.businessTaxStandard;
+    if (partnerProfile) {
+      brn = partnerProfile.brn ?? "";
+      bankAccount = partnerProfile.bankAccount ?? "";
+      businessName = partnerProfile.businessName ?? "";
+      businessTaxStandard = partnerProfile.businessTaxStandard ?? "";
     }
     result.push({
       partnerName: doc.id,


### PR DESCRIPTION
- 파트너 정산내역을 올린 이후 해당 파트너가 계약업체목록에서 삭제되었을 때, 그 정산내역이 있는 달을 조회하려 할 때 에러가 생기는 이슈 수정