### PR TITLE
fix: Mantine Popover.Target forwardRef (날짜선택 팝오버 위치 수정)

### DIFF
--- a/app/components/date.tsx
+++ b/app/components/date.tsx
@@ -1,4 +1,5 @@
 import { Popover } from "@mantine/core";
+import { forwardRef } from "react";
 import { DayPicker } from "react-day-picker";
 
 import dayPickerStyles from "react-day-picker/dist/style.css";
@@ -82,7 +83,7 @@ export function MonthSelectPopover({
   return (
     <Popover>
       <Popover.Target>
-        <MonthBox>{monthStr}</MonthBox>
+        <DateTargetBox>{monthStr}</DateTargetBox>
       </Popover.Target>
       <Popover.Dropdown>
         <div style={{ display: "flex", fontSize: "20px", fontWeight: "700" }}>
@@ -107,9 +108,9 @@ export function DaySelectPopover({
   return (
     <Popover>
       <Popover.Target>
-        <MonthBox>
+        <DateTargetBox>
           {selectedDate !== undefined ? dateToDayStr(selectedDate) : ""}
-        </MonthBox>
+        </DateTargetBox>
       </Popover.Target>
       <Popover.Dropdown>
         <DayPicker
@@ -132,28 +133,25 @@ export function DaySelectPopover({
   );
 }
 
-function MonthBox({
-  children,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
-  const defaultStyles: React.CSSProperties = {
-    border: "3px solid #000000",
-    width: "140px",
-    minWidth: "140px",
-    fontSize: "20px",
-    lineHeight: "20px",
-    padding: "6px",
-    height: "40px",
-    textAlign: "center",
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    cursor: "pointer",
-  };
-
-  return (
-    <div style={defaultStyles} {...props}>
-      {children}
-    </div>
-  );
-}
+const DateTargetBox = forwardRef((props: any, ref: React.ForwardedRef<any>) => (
+  <div
+    ref={ref}
+    style={{
+      border: "3px solid #000000",
+      width: "140px",
+      minWidth: "140px",
+      fontSize: "20px",
+      lineHeight: "20px",
+      padding: "6px",
+      height: "40px",
+      textAlign: "center",
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      cursor: "pointer",
+    }}
+    {...props}
+  >
+    {props.children}
+  </div>
+));


### PR DESCRIPTION
https://v5.mantine.dev/core/popover/#required-ref-prop

Mantine에서 Popover 사용시 Target에 커스텀 컴포넌트를 넣을 경우 해당 컴포넌트에 forwardRef를 해야 Dropdown이 정상적으로 표시됨, 이걸 수정하여 팝오버가 이상한 위치에 뜨던 걸 수정