### PR TITLE
fix: seller 예약구매 & providerName for settlement-manage-detail edit page

### DIFF
--- a/app/components/seller.tsx
+++ b/app/components/seller.tsx
@@ -60,6 +60,7 @@ export function SellerSelect({
         { value: "용산쇼룸", label: "용산쇼룸" },
         { value: "오늘의집", label: "오늘의집" },
         { value: "카카오", label: "카카오" },
+        { value: "예약거래", label: "예약거래" },
         { value: "etc", label: "기타" },
       ]}
       styles={{


### PR DESCRIPTION
- 판매처 선택 드롭다운에도 '예약구매' 항목 추가
- 정산내역에 공급처명 항목을 추가했는데, 정산내역관리 - 자세히보기 페이지에선 이를 입력할 수 없던 점 수정