### PR TITLE
feature: 할인내역 등록 시 기존 정산내역에 반영됨

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -41,7 +41,6 @@ export function MobileHeaderBox({
     justifyContent: "space-between",
     fontSize: "16px",
     fontWeight: 700,
-    lineHeight: "50px",
   };
 
   return (
@@ -104,6 +103,7 @@ export function MobileAdminHeader({
         <div
           style={{
             display: "flex",
+            alignItems: "center",
           }}
         >
           <div
@@ -111,6 +111,7 @@ export function MobileAdminHeader({
               color: "#00000080",
               fontSize: "15px",
               cursor: "pointer",
+              lineHeight: "40px",
             }}
             onClick={onLogoutClick}
           >
@@ -183,12 +184,13 @@ export function MobilePartnerHeader({
             style={{ cursor: "pointer" }}
           />
         </div>
-        <div style={{ display: "flex" }}>
+        <div style={{ display: "flex", alignItems: "center" }}>
           <div
             style={{
               color: "#00000080",
               fontSize: "15px",
               cursor: "pointer",
+              display: "flex",
             }}
             onClick={onLogoutClick}
           >

--- a/app/components/settlement_table.tsx
+++ b/app/components/settlement_table.tsx
@@ -14,7 +14,7 @@ export type SettlementItem = {
   orderNumber: string;
   productName: string;
   optionName: string;
-  price: number;
+  price: number; //정상판매가
   amount: number;
   orderer: string;
   receiver: string;
@@ -22,7 +22,10 @@ export type SettlementItem = {
   fee: number;
   shippingFee: number;
   orderTag: string;
-  sale: number;
+  isDiscounted: boolean;
+  discountedPrice?: number; //할인판매가
+  partnerDiscountLevy?: number //업체부담할인금
+  lofaAdjustmentFee?: number //로파조정수수료
 };
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
@@ -278,16 +281,6 @@ function SettlementItem({
   }, [check]);
   const [isChecked, setIsChecked] = useState<boolean>(check);
 
-  const saleString = useMemo(() => {
-    if (!item.sale) {
-      return "0";
-    } else if (item.sale > 0 && item.sale <= 1) {
-      return item.sale * 100 + "%";
-    } else {
-      return item.sale + "";
-    }
-  }, [item]);
-
   return (
     <SettlementItemBox isMobile={isMobileMemo} key={`SettlementItem-${index}`}>
       <Checkbox
@@ -349,7 +342,7 @@ function SettlementItem({
         isMobile={isMobileMemo}
         styleOverrides={{ width: "60px", minWidth: "60px" }}
       >
-        {saleString}
+        {item.isDiscounted ? "O" : "X"}
       </TextBox>
       <TextBox
         isMobile={isMobileMemo}
@@ -467,7 +460,7 @@ export function SettlementTable({
           isMobile={isMobileMemo}
           styleOverrides={{ width: "60px", minWidth: "60px" }}
         >
-          세일적용
+          할인적용
         </TextBox>
         <TextBox
           isMobile={isMobileMemo}

--- a/app/components/settlement_table.tsx
+++ b/app/components/settlement_table.tsx
@@ -24,8 +24,8 @@ export type SettlementItem = {
   orderTag: string;
   isDiscounted: boolean;
   discountedPrice?: number; //할인판매가
-  partnerDiscountLevy?: number //업체부담할인금
-  lofaAdjustmentFee?: number //로파조정수수료
+  partnerDiscountLevy?: number; //업체부담할인금
+  lofaAdjustmentFee?: number; //로파조정수수료
 };
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
@@ -44,7 +44,6 @@ interface MarqueeOnHoverProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export function SettlementBox({ isMobile, children, ...props }: Props) {
   const boxStyles: React.CSSProperties = {
-    width: "inherit",
     height: "60%",
     minHeight: "60%",
     position: "relative",
@@ -313,7 +312,8 @@ function SettlementItem({
       <MarqueeOnHoverTextBox
         isMobile={isMobileMemo}
         containerStyleOverrides={{
-          width: isMobileMemo ? "300px" : "calc(50% - 348px)",
+          width: "320px",
+          minWidth: "320px",
         }}
         onMouseEnter={() => setIsNameHovered(true)}
         onMouseLeave={() => setIsNameHovered(false)}
@@ -324,7 +324,8 @@ function SettlementItem({
       <MarqueeOnHoverTextBox
         isMobile={isMobileMemo}
         containerStyleOverrides={{
-          width: isMobileMemo ? "300px" : "calc(50% - 438px)",
+          width: "320px",
+          minWidth: "320px",
         }}
         onMouseEnter={() => setIsOptionHovered(true)}
         onMouseLeave={() => setIsOptionHovered(false)}
@@ -336,19 +337,7 @@ function SettlementItem({
         isMobile={isMobileMemo}
         styleOverrides={{ width: "60px", minWidth: "60px" }}
       >
-        {item.price}
-      </TextBox>
-      <TextBox
-        isMobile={isMobileMemo}
-        styleOverrides={{ width: "60px", minWidth: "60px" }}
-      >
-        {item.isDiscounted ? "O" : "X"}
-      </TextBox>
-      <TextBox
-        isMobile={isMobileMemo}
-        styleOverrides={{ width: "90px", minWidth: "90px" }}
-      >
-        {item.shippingFee == 0 ? "X" : "O"}
+        {item.isDiscounted ? item.discountedPrice : item.price}
       </TextBox>
       <TextBox
         isMobile={isMobileMemo}
@@ -356,6 +345,25 @@ function SettlementItem({
       >
         {item.amount}
       </TextBox>
+      <TextBox
+        isMobile={isMobileMemo}
+        styleOverrides={{ width: "30px", minWidth: "30px" }}
+      >
+        {item.isDiscounted ? "O" : "X"}
+      </TextBox>
+      <TextBox
+        isMobile={isMobileMemo}
+        styleOverrides={{ width: "60px", minWidth: "60px" }}
+      >
+        {item.lofaAdjustmentFee ?? ""}
+      </TextBox>
+      <TextBox
+        isMobile={isMobileMemo}
+        styleOverrides={{ width: "30px", minWidth: "30px" }}
+      >
+        {item.shippingFee == 0 ? "X" : "O"}
+      </TextBox>
+
       <TextBox
         isMobile={isMobileMemo}
         styleOverrides={{ width: "60px", minWidth: "60px" }}
@@ -431,7 +439,8 @@ export function SettlementTable({
         <MarqueeOnHoverTextBox
           isMobile={isMobileMemo}
           containerStyleOverrides={{
-            width: isMobileMemo ? "300px" : "calc(50% - 348px)",
+            width: "320px",
+            minWidth: "320px",
           }}
           isHovered={false}
           onMouseEnter={() => {}}
@@ -442,7 +451,8 @@ export function SettlementTable({
         <MarqueeOnHoverTextBox
           isMobile={isMobileMemo}
           containerStyleOverrides={{
-            width: isMobileMemo ? "300px" : "calc(50% - 438px)",
+            width: "320px",
+            minWidth: "320px",
           }}
           isHovered={false}
           onMouseEnter={() => {}}
@@ -458,21 +468,33 @@ export function SettlementTable({
         </TextBox>
         <TextBox
           isMobile={isMobileMemo}
-          styleOverrides={{ width: "60px", minWidth: "60px" }}
+          styleOverrides={{ width: "30px", minWidth: "30px" }}
         >
-          할인적용
-        </TextBox>
-        <TextBox
-          isMobile={isMobileMemo}
-          styleOverrides={{ width: "90px", minWidth: "90px" }}
-        >
-          배송비 정산
+          수량
         </TextBox>
         <TextBox
           isMobile={isMobileMemo}
           styleOverrides={{ width: "30px", minWidth: "30px" }}
         >
-          수량
+          할인
+        </TextBox>
+        <TextBox
+          isMobile={isMobileMemo}
+          styleOverrides={{ width: "60px", minWidth: "60px" }}
+        >
+          조정수수료
+        </TextBox>
+        <TextBox
+          isMobile={isMobileMemo}
+          styleOverrides={{
+            width: "30px",
+            minWidth: "30px",
+            whiteSpace: "pre-line",
+            lineHeight: 1.2,
+          }}
+        >
+          {`배송비
+          정산`}
         </TextBox>
         <TextBox
           isMobile={isMobileMemo}

--- a/app/routes/admin/settlement-manage-detail.tsx
+++ b/app/routes/admin/settlement-manage-detail.tsx
@@ -69,7 +69,7 @@ interface PartnerNameInputBoxProps
 
 const PartnerNameInputBox: React.FC<PartnerNameInputBoxProps> = (props) => {
   const styles: React.CSSProperties = {
-    width: "140px",
+    width: "200px",
     height: "40px",
     border: "3px solid black",
     padding: "6px",
@@ -574,7 +574,7 @@ export default function AdminSettlementShare() {
       partnerName: "",
       orderTag: orderTagEdit,
       providerName: providerNameEdit,
-      isDiscounted: false
+      isDiscounted: false,
     };
 
     const checkValid = isSettlementItemValid(newSettlement);
@@ -1149,7 +1149,7 @@ const schema = [
     column: "판매단가",
     type: Number,
     value: (item: SettlementItem) => {
-      return Number(item.price);
+      return Number(item.isDiscounted ? item.discountedPrice : item.price);
     },
     width: 15,
   },
@@ -1159,6 +1159,18 @@ const schema = [
     value: (item: SettlementItem) => {
       return Number(item.amount);
     },
+    width: 10,
+  },
+  {
+    column: "할인적용",
+    type: String,
+    value: (item: SettlementItem) => (item.isDiscounted ? "O" : "X"),
+    width: 10,
+  },
+  {
+    column: "조정수수료",
+    type: Number,
+    value: (item: SettlementItem) => Number(item.lofaAdjustmentFee ?? "0"),
     width: 10,
   },
   {
@@ -1173,12 +1185,7 @@ const schema = [
     value: (item: SettlementItem) => item.receiver,
     width: 10,
   },
-  {
-    column: "할인적용",
-    type: String ,
-    value: (item: SettlementItem) => item.isDiscounted ? "O" : "X",
-    width: 10,
-  },
+
   {
     column: "주문태그",
     type: String,

--- a/app/routes/admin/settlement-manage-detail.tsx
+++ b/app/routes/admin/settlement-manage-detail.tsx
@@ -529,7 +529,6 @@ export default function AdminSettlementShare() {
       setAmountEdit(settlement.amount);
       setFeeEdit(settlement.fee);
       setShippingFeeEdit(settlement.shippingFee);
-      setSaleEdit(settlement.sale);
       setOrderTagEdit(settlement.orderTag);
       setOrdererEdit(settlement.orderer);
       setReceiverEdit(settlement.receiver);
@@ -574,8 +573,8 @@ export default function AdminSettlementShare() {
       shippingFee: shippingFeeEdit,
       partnerName: "",
       orderTag: orderTagEdit,
-      sale: saleEdit,
       providerName: providerNameEdit,
+      isDiscounted: false
     };
 
     const checkValid = isSettlementItemValid(newSettlement);
@@ -1175,9 +1174,9 @@ const schema = [
     width: 10,
   },
   {
-    column: "세일반영",
-    type: Number,
-    value: (item: SettlementItem) => item.sale,
+    column: "할인적용",
+    type: String ,
+    value: (item: SettlementItem) => item.isDiscounted ? "O" : "X",
     width: 10,
   },
   {

--- a/app/routes/admin/settlement-share.tsx
+++ b/app/routes/admin/settlement-share.tsx
@@ -179,7 +179,7 @@ export default function AdminSettlementShare() {
             fee: -1,
             shippingFee: -1,
             orderTag: element.주문태그?.toString() ?? "",
-            sale: element.세일적용 ?? 0,
+            isDiscounted: false
           };
 
           let checkValidResult = isSettlementItemValid(item);

--- a/app/routes/partner/settlement-list.tsx
+++ b/app/routes/partner/settlement-list.tsx
@@ -505,7 +505,7 @@ const schema = [
     column: "판매단가",
     type: Number,
     value: (item: SettlementItem) => {
-      return Number(item.price);
+      return Number(item.isDiscounted ? item.discountedPrice : item.price);
     },
     width: 15,
   },
@@ -515,6 +515,18 @@ const schema = [
     value: (item: SettlementItem) => {
       return Number(item.amount);
     },
+    width: 10,
+  },
+  {
+    column: "할인적용",
+    type: String,
+    value: (item: SettlementItem) => (item.isDiscounted ? "O" : "X"),
+    width: 10,
+  },
+  {
+    column: "조정수수료",
+    type: Number,
+    value: (item: SettlementItem) => Number(item.lofaAdjustmentFee ?? "0"),
     width: 10,
   },
   {
@@ -529,12 +541,7 @@ const schema = [
     value: (item: SettlementItem) => item.receiver,
     width: 10,
   },
-  {
-    column: "할인 적용",
-    type: Number,
-    value: (item: SettlementItem) => item.isDiscounted ? "O" : "X",
-    width: 10,
-  },
+
   {
     column: "주문태그",
     type: String,

--- a/app/routes/partner/settlement-list.tsx
+++ b/app/routes/partner/settlement-list.tsx
@@ -530,9 +530,9 @@ const schema = [
     width: 10,
   },
   {
-    column: "세일반영",
+    column: "할인 적용",
     type: Number,
-    value: (item: SettlementItem) => item.sale,
+    value: (item: SettlementItem) => item.isDiscounted ? "O" : "X",
     width: 10,
   },
   {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a6d24143-fd48-411f-9459-f31586762ff6)

- 할인내역을 공유한 후, (1) 해당 기간 내에 주문일이 있고, (2) 할인대상 상품과 상품명이 같은 정산건에 대해 할인공식을 적용함. 
- 할인이 O인 경우 기존 가격 항목(price)이 아닌, 할인대상건에만 존재하는 할인판매가(discountedPrice)로 표시가 되며, 할인내역에 있는 업체부담할인가(partnerDiscountLevy)만큼 정산식에서 차감되며, 로파조정수수료(lofaAdjustmentFee)만큼 보완됨
- 할인내역은 정산내역의 항목을 수정하며, 이에 따라 정산내역이 등록/수정될 시 실행되는 합계 계싼(onSettlementUpdate)도 다시 실행되며 정산금 합계를 반영함. 
- 엑셀 다운로드시 할인여부와 조정수수료를 표시하고, 할인 상품일 시 정가가 아닌 할인판매가를 판매단가로 보여줌

- 입력창 크기, 모바일 화면의 상단 등 일부 UI 추가 수정