### PR TITLE
feature: 할인내역 추가 시 기존 내용 중복일 경우 금지 & 기간 관련 수정

### DIFF
--- a/app/components/discount.tsx
+++ b/app/components/discount.tsx
@@ -115,7 +115,7 @@ export function checkDiscountData(item: DiscountData) {
   if (!(item.startDate instanceof Date) || isNaN(item.startDate.getTime())) {
     return {
       isValid: false,
-      message: `주문일이 유효하지 않은 항목이 존재합니다. (${item.startDate}) `,
+      message: `시작일이 유효하지 않은 항목이 존재합니다. (${item.startDate}) `,
     };
   }
 
@@ -123,7 +123,15 @@ export function checkDiscountData(item: DiscountData) {
   if (!(item.endDate instanceof Date) || isNaN(item.endDate.getTime())) {
     return {
       isValid: false,
-      message: `주문일이 유효하지 않은 항목이 존재합니다. (${item.endDate}) `,
+      message: `종료일이 유효하지 않은 항목이 존재합니다. (${item.endDate}) `,
+    };
+  }
+
+  // 시작일은 종료일보다 앞이여야 함
+  if (item.startDate > item.endDate) {
+    return {
+      isValid: false,
+      message: `시작일이 종료일보다 앞이여야 합니다.`,
     };
   }
 

--- a/app/routes/admin/order-edit-discount-manage.tsx
+++ b/app/routes/admin/order-edit-discount-manage.tsx
@@ -53,8 +53,8 @@ export const loader: LoaderFunction = async ({ request }) => {
     const partnerName = url.searchParams.get("partner-name");
     const productName = url.searchParams.get("product-name");
 
-    const startDate = new Date(`${startDateStr}T00:00:00Z`);
-    const endDate = new Date(`${endDateStr}T23:59:59Z`);
+    const startDate = new Date(`${startDateStr}T00:00:00.000+09:00`);
+    const endDate = new Date(`${endDateStr}T23:59:59.000+09:00`);
 
     if (startDate > endDate) {
       return json({
@@ -69,6 +69,7 @@ export const loader: LoaderFunction = async ({ request }) => {
       partnerName: partnerName ?? "",
       productName: productName ?? "",
     });
+
     return json({
       status: "ok",
       data: searchResult,

--- a/app/routes/admin/order-edit-discount-manage.tsx
+++ b/app/routes/admin/order-edit-discount-manage.tsx
@@ -56,6 +56,13 @@ export const loader: LoaderFunction = async ({ request }) => {
     const startDate = new Date(`${startDateStr}T00:00:00Z`);
     const endDate = new Date(`${endDateStr}T23:59:59Z`);
 
+    if (startDate > endDate) {
+      return json({
+        status: "error",
+        message: `시작일은 종료일보다 앞이여야 합니다.`,
+      });
+    }
+
     const searchResult = await getDiscountData({
       startDate: startDate,
       endDate: endDate,

--- a/app/routes/admin/order-edit-discount.tsx
+++ b/app/routes/admin/order-edit-discount.tsx
@@ -48,7 +48,10 @@ export const action: ActionFunction = async ({ request }) => {
           message: `할인내역 자료가 등록되었습니다. 잠시 후 DB에 반영될 예정입니다.`,
         });
       } else {
-        console.log("error", result);
+        return json({
+          status: "error",
+          message: result,
+        });
       }
     }
   }

--- a/app/routes/admin/revenue-calculate.tsx
+++ b/app/routes/admin/revenue-calculate.tsx
@@ -31,8 +31,8 @@ export const loader: LoaderFunction = async ({ request }) => {
       });
     }
 
-    const startDate = new Date(`${startDateStr}T00:00:00Z`);
-    const endDate = new Date(`${endDateStr}T23:59:59Z`);
+    const startDate = new Date(`${startDateStr}T00:00:00.000+09:00`);
+    const endDate = new Date(`${endDateStr}T23:59:59.000+09:00`);
 
     if (startDate > endDate) {
       return json({

--- a/app/routes/admin/revenue-calculate.tsx
+++ b/app/routes/admin/revenue-calculate.tsx
@@ -34,6 +34,13 @@ export const loader: LoaderFunction = async ({ request }) => {
     const startDate = new Date(`${startDateStr}T00:00:00Z`);
     const endDate = new Date(`${endDateStr}T23:59:59Z`);
 
+    if (startDate > endDate) {
+      return json({
+        status: "error",
+        message: `시작일은 종료일보다 앞이여야 합니다.`,
+      });
+    }
+
     const searchResult = await getRevenueStats({
       startDate: startDate,
       endDate: endDate,

--- a/app/routes/admin/revenue-db.tsx
+++ b/app/routes/admin/revenue-db.tsx
@@ -58,6 +58,13 @@ export const loader: LoaderFunction = async ({ request }) => {
     const startDate = new Date(`${startDateStr}T00:00:00Z`);
     const endDate = new Date(`${endDateStr}T23:59:59Z`);
 
+    if (startDate > endDate) {
+      return json({
+        status: "error",
+        message: `시작일은 종료일보다 앞이여야 합니다.`,
+      });
+    }
+
     const searchResult = await getRevenueData({
       startDate: startDate,
       endDate: endDate,
@@ -208,8 +215,6 @@ export default function Page() {
   //사용자에게 보이는 값은 여기서 +1
   const [pageIndex, setPageIndex] = useState<number>(0);
 
-
-
   //볼 항목 선택
   //TODO
 
@@ -276,10 +281,15 @@ export default function Page() {
 
   useEffect(() => {
     resetCheck(pageIndex);
-  }, [pageIndex])
+  }, [pageIndex]);
 
-  function resetCheck(pageIndex: number){
-    const newArr = Array(Math.min(revenueDataItems.slice(pageIndex * 100, (pageIndex + 1) * 100).length, 100)).fill(false);
+  function resetCheck(pageIndex: number) {
+    const newArr = Array(
+      Math.min(
+        revenueDataItems.slice(pageIndex * 100, (pageIndex + 1) * 100).length,
+        100
+      )
+    ).fill(false);
     setItemsChecked(newArr);
   }
 
@@ -289,7 +299,7 @@ export default function Page() {
 
   function onCheckAll(isChecked: boolean) {
     setIsLoading(true);
-    for(let i = 0; i < itemsChecked.length; i++){
+    for (let i = 0; i < itemsChecked.length; i++) {
       itemsChecked[i] = isChecked;
     }
     setIsLoading(false);
@@ -562,17 +572,16 @@ export default function Page() {
       )}
       {revenueDataItems ? (
         <PageIndex
-        pageCount={Math.ceil(revenueDataItems.length / 100)}
-        currentIndex={pageIndex}
-        onIndexClick={(index: number) => {
-          setPageIndex(index);
-          resetCheck(index);
-        }}
-      />
+          pageCount={Math.ceil(revenueDataItems.length / 100)}
+          currentIndex={pageIndex}
+          onIndexClick={(index: number) => {
+            setPageIndex(index);
+            resetCheck(index);
+          }}
+        />
       ) : (
         <></>
       )}
-
 
       <Space h={20} />
       <BlackButton onClick={() => setIsDeleteModalOpened(true)}>

--- a/app/routes/admin/revenue-db.tsx
+++ b/app/routes/admin/revenue-db.tsx
@@ -55,8 +55,8 @@ export const loader: LoaderFunction = async ({ request }) => {
     const cs = url.searchParams.get("cs");
     const filterDiscount = url.searchParams.get("filter-discount");
 
-    const startDate = new Date(`${startDateStr}T00:00:00Z`);
-    const endDate = new Date(`${endDateStr}T23:59:59Z`);
+    const startDate = new Date(`${startDateStr}T00:00:00.000+09:00`);
+    const endDate = new Date(`${endDateStr}T23:59:59.000+09:00`);
 
     if (startDate > endDate) {
       return json({

--- a/app/routes/admin/settlement-share.tsx
+++ b/app/routes/admin/settlement-share.tsx
@@ -1,4 +1,4 @@
-import { LoadingOverlay } from "@mantine/core";
+import { LoadingOverlay, Space } from "@mantine/core";
 import { ActionFunction, json, LoaderFunction } from "@remix-run/node";
 import {
   useActionData,
@@ -370,6 +370,8 @@ export default function AdminSettlementShare() {
         ) : (
           <></>
         )}
+        <Space h={20} />
+        <div>{`* 할인은 '주문서 수정 > 할인내역 추가'에서 등록한 할인내역을 바탕으로 정산내역 공유 후 적용됩니다.`}</div>
       </PageLayout>
     </>
   );

--- a/app/services/firebase.server.ts
+++ b/app/services/firebase.server.ts
@@ -2365,8 +2365,8 @@ export async function getDiscountData({
   let discountDataQuery = query(
     discountDataRef,
     and(
-      where("startDate", ">=", Timestamp.fromDate(startDate)),
-      where("endDate", "<=", Timestamp.fromDate(endDate))
+      where("startDate", "<=", Timestamp.fromDate(endDate)),
+      where("endDate", ">=", Timestamp.fromDate(startDate))
     )
   );
 

--- a/app/services/firebase.server.ts
+++ b/app/services/firebase.server.ts
@@ -49,6 +49,7 @@ import {
 } from "~/components/revenue_data";
 import { PartnerRevenueStat } from "~/components/revenue_stat";
 import { LofaSellers } from "~/components/seller";
+import { DiscountData } from "~/components/discount";
 
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
@@ -1943,8 +1944,6 @@ export async function sendSettlementNoticeEmail({
   };
 }
 
-
-
 /**
  * 수익통계자료를 업로드합니다.
  * @param settlements: JSON string of settlement items list
@@ -2291,6 +2290,29 @@ export async function getRevenueStats({
 export async function addDiscountData({ data }: { data: string }) {
   try {
     const time = new Date().getTime();
+
+    //이미 올라와있는 할인내역과 겹치는게 없는지 먼저 확인
+    const discountData: DiscountData[] = JSON.parse(data);
+
+    for (let i = 0; i < discountData.length; i++) {
+      const item = discountData[i];
+      const startDate = new Date(`${item.startDate}`);
+      const endDate = new Date(`${item.endDate}`);
+      const discountDataRef = collection(firestore, `discount-db`);
+      let discountDataQuery = query(
+        discountDataRef,
+        where("productName", "==", item.productName),
+        where("endDate", ">=", Timestamp.fromDate(startDate)),
+        where("startDate", "<=", Timestamp.fromDate(endDate))
+      );
+      const querySnapshot = await getDocs(discountDataQuery);
+      if (!querySnapshot.empty) {
+        return `중복된 할인내역이 있습니다. (${dateToDayStr(
+          startDate
+        )}~${dateToDayStr(endDate)} ${item.productName})`;
+      }
+    }
+
     await setDoc(doc(firestore, `discount-data-add/data`), {
       json: data,
       updateTime: time,
@@ -2301,7 +2323,7 @@ export async function addDiscountData({ data }: { data: string }) {
       text: `[로파파트너] ${error.message ?? error}`,
       receiver: "01023540973",
     });
-    return error.message ?? error;
+    return (error.message as string) ?? (error as string);
   }
 }
 


### PR DESCRIPTION
- 할인내역을 추가할 때, 기존 할인내역과 상품이 같으면서 기간이 겹칠 경우 올리는 과정에서 차단당함
- 시작시기와 종료시기가 있는 항목 업로드 시, 시작점이 종료점보다 늦을 경우 금지
- 기간 검색 시, 시작점이 종료점보다 늦을 경우 검색되지 않음
- 기간으로 기간 검색 시, 기존에는 검색기간이 대상기간을 완전히 포함해야 했으나, 이제 일부라도 겹치면 검색됨
- 기간으로 검색 시, 시차로 인해 검색되는 기간이 이상하던 문제 수정