### PR TITLE
fix: check isDiscount before using adjustmentFee and discountedPrice

### DIFF
--- a/app/components/settlement_table.tsx
+++ b/app/components/settlement_table.tsx
@@ -355,7 +355,7 @@ function SettlementItem({
         isMobile={isMobileMemo}
         styleOverrides={{ width: "60px", minWidth: "60px" }}
       >
-        {item.lofaAdjustmentFee ?? ""}
+        {item.isDiscounted ? item.lofaAdjustmentFee : ""}
       </TextBox>
       <TextBox
         isMobile={isMobileMemo}

--- a/app/routes/admin/settlement-manage-detail.tsx
+++ b/app/routes/admin/settlement-manage-detail.tsx
@@ -1170,7 +1170,8 @@ const schema = [
   {
     column: "조정수수료",
     type: Number,
-    value: (item: SettlementItem) => Number(item.lofaAdjustmentFee ?? "0"),
+    value: (item: SettlementItem) =>
+      Number(item.isDiscounted ? item.lofaAdjustmentFee : "0"),
     width: 10,
   },
   {

--- a/app/routes/partner/settlement-list.tsx
+++ b/app/routes/partner/settlement-list.tsx
@@ -526,7 +526,8 @@ const schema = [
   {
     column: "조정수수료",
     type: Number,
-    value: (item: SettlementItem) => Number(item.lofaAdjustmentFee ?? "0"),
+    value: (item: SettlementItem) =>
+      Number(item.isDiscounted ? item.lofaAdjustmentFee : "0"),
     width: 10,
   },
   {


### PR DESCRIPTION
- 정산내역의 lofaAdjustmentFee가 원래 isDiscounted가 false면 없는게 정상이라 이론상 lofaAdjustmentFee를 바로 사용하려 시도하고, 없으면 0으로 두는게 문제는 없지만, 통일성을 위해 isDiscounted를 먼저 확인하도록 수정