### PR TITLE
fix: yaxis font size & tooltip

### DIFF
--- a/app/components/chart.tsx
+++ b/app/components/chart.tsx
@@ -106,6 +106,7 @@ export function MyStackedBarChart({ chartData }: { chartData: BarChartInput }) {
 
           return value.toLocaleString();
         }}
+        fontSize={12}
       />
       <Tooltip
         content={({ payload, label }) => {
@@ -136,7 +137,7 @@ export function MyStackedBarChart({ chartData }: { chartData: BarChartInput }) {
                           minimumFractionDigits: 0,
                           maximumFractionDigits: 0,
                         }) ?? 0
-                      }`}</div>
+                      }원`}</div>
                     </div>
                     <Space h={5} />
                     <div style={{ display: "flex", textAlign: "left" }}>
@@ -146,7 +147,7 @@ export function MyStackedBarChart({ chartData }: { chartData: BarChartInput }) {
                           minimumFractionDigits: 0,
                           maximumFractionDigits: 0,
                         }) ?? 0
-                      }`}</div>
+                      }원`}</div>
                     </div>
                     <Space h={15} />
                   </>


### PR DESCRIPTION
- 막대그래프 좌측의 숫자 글꼴 크기 수정
- 마우스 올릴 때 나오는 툴팁의 금액 뒤에 단위(원) 붙임