### PR TITLE
feature: settlement isSeparatingShippingFee

### DIFF
--- a/app/components/settlement_table.tsx
+++ b/app/components/settlement_table.tsx
@@ -27,6 +27,7 @@ export type SettlementItem = {
   partnerDiscountLevy?: number; //업체부담할인금
   lofaAdjustmentFee?: number; //로파조정수수료
   isDiscountManuallyFixed?: boolean; //할인이 수동으로 수정되었는지 여부, 이게 true이면 할인이 자동으로 적용되지 않음
+  isSeparatingShippingFee?: boolean; //배송비 분리 여부
 };
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {

--- a/app/routes/admin/settlement-manage-detail.tsx
+++ b/app/routes/admin/settlement-manage-detail.tsx
@@ -331,6 +331,9 @@ export default function AdminSettlementShare() {
   const [orderDateEdit, setOrderDateEdit] = useState<string>("");
   const [providerNameEdit, setProviderNameEdit] = useState<string>("");
 
+  const [isSeperatingShippingFee, setIsSeparatingShippingFee] =
+    useState<boolean>(false);
+
   const [isManuallyFixingDiscount, setIsManuallyFixingDiscount] =
     useState<boolean>(false);
   const [discountedPriceEdit, setDiscountedPriceEdit] = useState<number>(0);
@@ -593,6 +596,7 @@ export default function AdminSettlementShare() {
       setDiscountedPriceEdit(settlement.discountedPrice ?? settlement.price);
       setPartnerDiscountLevyEdit(settlement.partnerDiscountLevy ?? 0);
       setLofaAdjustmentFeeEdit(settlement.lofaAdjustmentFee ?? 0);
+      setIsSeparatingShippingFee(settlement.isSeparatingShippingFee ?? false);
     } else {
       setSellerEdit("");
       setOrderNumberEdit("");
@@ -609,6 +613,7 @@ export default function AdminSettlementShare() {
       setDiscountedPriceEdit(0);
       setPartnerDiscountLevyEdit(0);
       setLofaAdjustmentFeeEdit(0);
+      setIsSeparatingShippingFee(false);
     }
   }
 
@@ -632,6 +637,7 @@ export default function AdminSettlementShare() {
       orderTag: orderTagEdit,
       providerName: providerNameEdit,
       isDiscounted: isDiscounted,
+      isSeparatingShippingFee: isSeperatingShippingFee,
     };
 
     if (isManuallyFixingDiscount || isDiscounted) {
@@ -930,14 +936,6 @@ export default function AdminSettlementShare() {
               alignItems: "center",
             }}
           >
-            <div style={{ width: "100px" }}>수수료</div>
-            <EditInputBox
-              type="number"
-              name="fee"
-              value={feeEdit}
-              onChange={(e) => setFeeEdit(Number(e.target.value))}
-              required
-            />
             <div style={{ width: "100px" }}>배송비</div>
             <EditInputBox
               type="number"
@@ -946,7 +944,40 @@ export default function AdminSettlementShare() {
               onChange={(e) => setShippingFeeEdit(Number(e.target.value))}
               required
             />
+            <div style={{ width: "100px" }}>수수료</div>
+            <EditInputBox
+              type="number"
+              name="fee"
+              value={feeEdit}
+              onChange={(e) => setFeeEdit(Number(e.target.value))}
+              required
+            />
           </div>
+          <Space h={10} />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <div style={{ width: "150px", fontSize: "16px" }}>
+              배송비 별도 적용
+            </div>
+            <Checkbox
+              size={"sm"}
+              checked={isSeperatingShippingFee}
+              onChange={(event) => {
+                setIsSeparatingShippingFee(event.currentTarget.checked);
+                if (event.currentTarget.checked) {
+                  setNoticeModalStr(
+                    "배송비 별도 적용을 체크할 경우, 해당 주문건은 주문번호 중복 여부에 관계 없이 배송비가 합산에 적용됩니다."
+                  );
+                  setIsNoticeModalOpened(true);
+                }
+              }}
+            />
+          </div>
+          <Space h={10} />
           <div
             style={{
               display: "flex",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5a4dc961-eb4b-4389-a138-a82dad280d6e)

- 정산내역 수정에서 '배송비 별도 적용' 체크를 추가하여, 해당 건은 주문번호 목록을 추가시키지 않고, 중복 주문번호가 이미 있어도 배송비가 0원 처리되지 않음. 