### PR TITLE
feature: '발신함/수신함'을 '쪽지함'으로 변경

### DIFF
--- a/app/components/message.tsx
+++ b/app/components/message.tsx
@@ -9,17 +9,17 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   isFromPartner?: boolean;
 }
 
-export type NoticeItem = {
+export type MessageItem = {
   partnerName: string;
   docId: string;
   sharedDate: string | undefined;
-  topic: NoticeTopic;
+  topic: MessageTopic;
   detail: string;
   replies: string[];
   isFromPartner: boolean;
 };
 
-type NoticeTopic =
+type MessageTopic =
   | "교환요청"
   | "반품요청"
   | "배송 중 파손 고지"
@@ -30,7 +30,7 @@ type NoticeTopic =
   | "재고요청"
   | "기타";
 
-function NoticeBox({ children, ...props }: Props) {
+function MessageBox({ children, ...props }: Props) {
   const boxStyles: React.CSSProperties = {
     backgroundColor: "#d9d9d9",
     border: "1px solid black",
@@ -45,7 +45,7 @@ function NoticeBox({ children, ...props }: Props) {
   );
 }
 
-function NoticeGridContainer({
+function MessageGridContainer({
   children,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
@@ -61,7 +61,7 @@ function NoticeGridContainer({
   );
 }
 
-function NoticeGridItem({
+function MessageGridItem({
   children,
   isFromPartner,
   styleOverrides,
@@ -166,14 +166,14 @@ export function TopicSelect({
   );
 }
 
-export function AdminNotice({
-  noticeItem,
+export function AdminMessage({
+  messageItem,
   monthStr,
   key,
 }: // isEdit,
 // onEditClick,
 {
-  noticeItem: NoticeItem;
+  messageItem: MessageItem;
   monthStr: string;
   key: string;
   // isEdit: boolean;
@@ -184,10 +184,10 @@ export function AdminNotice({
   const [isEditModalOpened, setIsEditModalOpened] = useState<boolean>(false);
   const [isShareModalOpened, setIsShareModalOpened] = useState<boolean>(false);
   const [partnerNameEdit, setPartnerNameEdit] = useState<string>(
-    noticeItem.partnerName
+    messageItem.partnerName
   );
-  const [topicEdit, setTopicEdit] = useState<string>(noticeItem.topic);
-  const [detailEdit, setDetailEdit] = useState<string>(noticeItem.detail);
+  const [topicEdit, setTopicEdit] = useState<string>(messageItem.topic);
+  const [detailEdit, setDetailEdit] = useState<string>(messageItem.detail);
   return (
     <div key={key}>
       {/* 삭제 모달*/}
@@ -202,7 +202,7 @@ export function AdminNotice({
             fontWeight: "700",
           }}
         >
-          해당 알림을 삭제하시겠습니까?
+          해당 쪽지를 삭제하시겠습니까?
           <div style={{ height: "20px" }} />
           <div style={{ display: "flex", justifyContent: "center" }}>
             <ModalButton onClick={() => setIsDeleteModalOpened(false)}>
@@ -212,7 +212,7 @@ export function AdminNotice({
               <input type="hidden" value={"delete"} name="action" required />
               <input
                 type="hidden"
-                value={noticeItem.docId}
+                value={messageItem.docId}
                 name="id"
                 required
               />
@@ -240,8 +240,8 @@ export function AdminNotice({
             fontWeight: "700",
           }}
         >
-          해당 알림을 공유하시겠십니까? <br />
-          공유한 알림은 수정할 수 없습니다.
+          해당 쪽지를 공유하시겠십니까? <br />
+          공유한 쪽지는 수정할 수 없습니다.
           <div style={{ height: "20px" }} />
           <div style={{ display: "flex", justifyContent: "center" }}>
             <ModalButton onClick={() => setIsShareModalOpened(false)}>
@@ -251,20 +251,20 @@ export function AdminNotice({
               <input type="hidden" value={"share"} name="action" required />
               <input
                 type="hidden"
-                value={noticeItem.docId}
+                value={messageItem.docId}
                 name="id"
                 required
               />
               <input type="hidden" value={monthStr} name="month" required />
               <input
                 type="hidden"
-                value={noticeItem.partnerName}
+                value={messageItem.partnerName}
                 name="partner"
                 required
               />
               <input
                 type="hidden"
-                value={noticeItem.topic}
+                value={messageItem.topic}
                 name="topic"
                 required
               />
@@ -286,7 +286,7 @@ export function AdminNotice({
           onSubmit={() => setIsEditModalOpened(false)}
         >
           <input type="hidden" value={"edit"} name="action" required />
-          <input type="hidden" value={noticeItem.docId} name="id" required />
+          <input type="hidden" value={messageItem.docId} name="id" required />
           <input type="hidden" value={monthStr} name="month" required />
           <div
             style={{
@@ -341,7 +341,7 @@ export function AdminNotice({
         </Form>
       </BasicModal>
 
-      <NoticeBox isFromPartner={noticeItem.isFromPartner}>
+      <MessageBox isFromPartner={messageItem.isFromPartner}>
         <div
           style={{
             display: "flex",
@@ -352,8 +352,8 @@ export function AdminNotice({
             alignItems: "center",
           }}
         >
-          <div>{noticeItem.partnerName}</div>
-          {noticeItem.sharedDate == undefined ? (
+          <div>{messageItem.partnerName}</div>
+          {messageItem.sharedDate == undefined ? (
             <div style={{ display: "flex" }}>
               <img
                 src={"/images/icon_edit.svg"}
@@ -401,24 +401,24 @@ export function AdminNotice({
             </div>
           )}
         </div>
-        <NoticeGridContainer>
-          <NoticeGridItem isFromPartner={noticeItem.isFromPartner}>
+        <MessageGridContainer>
+          <MessageGridItem isFromPartner={messageItem.isFromPartner}>
             <div style={{ padding: "13px", width: "120px" }}>공유 날짜</div>
             <div
               style={{
                 padding: "13px",
-                color: noticeItem.sharedDate == undefined ? "red" : "black",
+                color: messageItem.sharedDate == undefined ? "red" : "black",
               }}
             >
-              {noticeItem.sharedDate ?? "공유되지 않음"}
+              {messageItem.sharedDate ?? "공유되지 않음"}
             </div>
-          </NoticeGridItem>
-          <NoticeGridItem isFromPartner={noticeItem.isFromPartner}>
+          </MessageGridItem>
+          <MessageGridItem isFromPartner={messageItem.isFromPartner}>
             <div style={{ padding: "13px", width: "120px" }}>공유 주제</div>
-            <div style={{ padding: "13px" }}>{noticeItem.topic}</div>
-          </NoticeGridItem>
-          <NoticeGridItem
-            isFromPartner={noticeItem.isFromPartner}
+            <div style={{ padding: "13px" }}>{messageItem.topic}</div>
+          </MessageGridItem>
+          <MessageGridItem
+            isFromPartner={messageItem.isFromPartner}
             styleOverrides={{ gridColumnStart: "span 2" }}
           >
             <div style={{ padding: "13px", width: "120px" }}>상세 사유</div>
@@ -431,12 +431,12 @@ export function AdminNotice({
                 lineHeight: "1.5",
               }}
             >
-              {noticeItem.detail}
+              {messageItem.detail}
             </div>
-          </NoticeGridItem>
-          {noticeItem.replies.length > 0 ? (
-            <NoticeGridItem
-              isFromPartner={noticeItem.isFromPartner}
+          </MessageGridItem>
+          {messageItem.replies.length > 0 ? (
+            <MessageGridItem
+              isFromPartner={messageItem.isFromPartner}
               styleOverrides={{ gridColumnStart: "span 2" }}
             >
               <div
@@ -445,7 +445,7 @@ export function AdminNotice({
                 업체 회신
               </div>
               <div style={{ width: "calc(100% - 120px)" }}>
-                {noticeItem.replies.map((reply: string, index: number) => {
+                {messageItem.replies.map((reply: string, index: number) => {
                   return (
                     <div
                       style={{ padding: "13px", whiteSpace: "pre-line" }}
@@ -456,12 +456,12 @@ export function AdminNotice({
                   );
                 })}
               </div>
-            </NoticeGridItem>
+            </MessageGridItem>
           ) : (
             <></>
           )}
-          <NoticeGridItem
-            isFromPartner={noticeItem.isFromPartner}
+          <MessageGridItem
+            isFromPartner={messageItem.isFromPartner}
             styleOverrides={{ gridColumnStart: "span 2" }}
           >
             <Form
@@ -473,7 +473,7 @@ export function AdminNotice({
               <input type="hidden" value={"reply"} name="action" required />
               <input
                 type="hidden"
-                value={noticeItem.docId}
+                value={messageItem.docId}
                 name="id"
                 required
               />
@@ -482,10 +482,10 @@ export function AdminNotice({
                 {"메세지 추가"}
               </BlackButton>
             </Form>
-          </NoticeGridItem>
-        </NoticeGridContainer>
-      </NoticeBox>
-      {noticeItem.replies.length == 0 && noticeItem.sharedDate != undefined ? (
+          </MessageGridItem>
+        </MessageGridContainer>
+      </MessageBox>
+      {messageItem.replies.length == 0 && messageItem.sharedDate != undefined ? (
         <div style={{ padding: "13px", width: "120px", color: "#FF0000" }}>
           미회신
         </div>
@@ -496,30 +496,30 @@ export function AdminNotice({
   );
 }
 
-export function PartnerNotice({
-  noticeItem,
+export function PartnerMessage({
+  messageItem,
   monthStr,
 }: {
-  noticeItem: NoticeItem;
+  messageItem: MessageItem;
   monthStr: string;
 }) {
   return (
     <>
-      <NoticeBox isFromPartner={noticeItem.isFromPartner}>
+      <MessageBox isFromPartner={messageItem.isFromPartner}>
         <Form method="post" id="reply-form">
-          <NoticeGridContainer>
-            <NoticeGridItem isFromPartner={noticeItem.isFromPartner}>
+          <MessageGridContainer>
+            <MessageGridItem isFromPartner={messageItem.isFromPartner}>
               <div style={{ padding: "13px", width: "120px" }}>공유 날짜</div>
               <div style={{ padding: "13px" }}>
-                {noticeItem.sharedDate ?? "공유되지 않음"}
+                {messageItem.sharedDate ?? "공유되지 않음"}
               </div>
-            </NoticeGridItem>
-            <NoticeGridItem isFromPartner={noticeItem.isFromPartner}>
+            </MessageGridItem>
+            <MessageGridItem isFromPartner={messageItem.isFromPartner}>
               <div style={{ padding: "13px", width: "120px" }}>공유 주제</div>
-              <div style={{ padding: "13px" }}>{noticeItem.topic}</div>
-            </NoticeGridItem>
-            <NoticeGridItem
-              isFromPartner={noticeItem.isFromPartner}
+              <div style={{ padding: "13px" }}>{messageItem.topic}</div>
+            </MessageGridItem>
+            <MessageGridItem
+              isFromPartner={messageItem.isFromPartner}
               styleOverrides={{ gridColumnStart: "span 2" }}
             >
               <div style={{ padding: "13px", width: "120px" }}>상세 사유</div>
@@ -532,12 +532,12 @@ export function PartnerNotice({
                   lineHeight: "1.5",
                 }}
               >
-                {noticeItem.detail}
+                {messageItem.detail}
               </div>
-            </NoticeGridItem>
-            {noticeItem.replies.length > 0 ? (
-              <NoticeGridItem
-                isFromPartner={noticeItem.isFromPartner}
+            </MessageGridItem>
+            {messageItem.replies.length > 0 ? (
+              <MessageGridItem
+                isFromPartner={messageItem.isFromPartner}
                 styleOverrides={{ gridColumnStart: "span 2" }}
               >
                 <div
@@ -546,7 +546,7 @@ export function PartnerNotice({
                   회신 완료
                 </div>
                 <div style={{ width: "calc(100% - 120px)" }}>
-                  {noticeItem.replies.map((reply: string, index: number) => {
+                  {messageItem.replies.map((reply: string, index: number) => {
                     return (
                       <div
                         style={{ padding: "13px", whiteSpace: "pre-line" }}
@@ -557,30 +557,30 @@ export function PartnerNotice({
                     );
                   })}
                 </div>
-              </NoticeGridItem>
+              </MessageGridItem>
             ) : (
               <></>
             )}
-            <NoticeGridItem
-              isFromPartner={noticeItem.isFromPartner}
+            <MessageGridItem
+              isFromPartner={messageItem.isFromPartner}
               styleOverrides={{ gridColumnStart: "span 2", alignItems: "end" }}
             >
               <ReplyInputBox name="reply" form="reply-form" />
               <input type="hidden" value={"reply"} name="action" required />
               <input
                 type="hidden"
-                value={noticeItem.docId}
+                value={messageItem.docId}
                 name="id"
                 required
               />
               <input type="hidden" value={monthStr} name="month" required />
               <BlackButton type="submit">
-                {noticeItem.replies.length > 0 ? "추가답신" : "답신하기"}
+                {messageItem.replies.length > 0 ? "추가답신" : "답신하기"}
               </BlackButton>
-            </NoticeGridItem>
-          </NoticeGridContainer>
+            </MessageGridItem>
+          </MessageGridContainer>
         </Form>
-      </NoticeBox>
+      </MessageBox>
     </>
   );
 }

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -88,7 +88,7 @@ export function SubcategoryButton({
 }
 type AdminPathname =
   | null
-  | "alert"
+  | "message"
   | "dashboard"
   | "delayed-order"
   | "order-share"
@@ -109,7 +109,7 @@ type AdminPathname =
 
 type PartnerPathname =
   | null
-  | "alert"
+  | "message"
   | "dashboard"
   | "delayed-order"
   | "waybill-share"
@@ -218,8 +218,8 @@ export function AdminSidebar({
         setCurrentPage("dashboard");
         break;
 
-      case "/admin/alert":
-        setCurrentPage("alert");
+      case "/admin/message":
+        setCurrentPage("message");
         break;
 
       case "/admin/delayed-order":
@@ -319,7 +319,7 @@ export function AdminSidebar({
         <MenuButton name="정산내역 관리" pathname="settlement-manage" />
       )}
       <MenuButton name="상품등록 관리" pathname="product-manage" />
-      <MenuButton name="발신함 / 수신함" pathname="alert" />
+      <MenuButton name="쪽지함" pathname="message" />
       {isStaff ? (
         <></>
       ) : (
@@ -427,8 +427,8 @@ export function PartnerSidebar({
         setCurrentPage("dashboard");
         break;
 
-      case "/partner/alert":
-        setCurrentPage("alert");
+      case "/partner/message":
+        setCurrentPage("message");
         break;
 
       case "/partner/delayed-order":
@@ -475,7 +475,7 @@ export function PartnerSidebar({
       <MenuButton name="출고 지연주문건" pathname="delayed-order" />
       <MenuButton name="정산내역" pathname="settlement-list" />
       <MenuButton name="상품 관리" pathname="product-manage" />
-      <MenuButton name="발신함 / 수신함" pathname="alert" />
+      <MenuButton name="쪽지함" pathname="message" />
     </SidebarBox>
   );
 }

--- a/app/routes/admin/debug.tsx
+++ b/app/routes/admin/debug.tsx
@@ -1,14 +1,15 @@
 import { ActionFunction } from "@remix-run/node";
 import { useSubmit } from "@remix-run/react";
 import { useRef } from "react";
-import { debug_addExtraDataToRevenueDB } from "~/services/firebase/firebase-debug.server";
+import { debug_addExtraDataToRevenueDB, debug_changeNoticeToMessage } from "~/services/firebase/firebase-debug.server";
 
 export const action: ActionFunction = async ({ request }) => {
   console.log("request submitted");
   // await debug_fixRevenueDataProviderName("LOFA COLLAB", "로파콜랍");
   // await debug_fixRevenueDataProviderName("DOUBLE NOD", "더블노드");
   // await debug_fixRevenueDataProviderName("LOFA ORIGINAL", "로파오리지널");
-  await debug_addExtraDataToRevenueDB();
+  //await debug_addExtraDataToRevenueDB();
+  await debug_changeNoticeToMessage();
   return null;
 };
 

--- a/app/routes/partner/message.tsx
+++ b/app/routes/partner/message.tsx
@@ -12,17 +12,17 @@ import { LoaderFunction } from "react-router-dom";
 import { CommonButton } from "~/components/button";
 import { MonthSelectPopover } from "~/components/date";
 import { BasicModal, ModalButton } from "~/components/modal";
-import { NoticeItem, PartnerNotice, TopicSelect } from "~/components/notice";
+import { MessageItem, PartnerMessage, TopicSelect } from "~/components/message";
 import { PageLayout } from "~/components/page_layout";
 import {
-  addNotice,
-  getSharedNotices,
-  replyNotice,
-} from "~/services/firebase/notice.server";
+  addMessage,
+  getSharedMessages,
+  replyMessage,
+} from "~/services/firebase/message.server";
 import { requireUser } from "~/services/session.server";
 import { dateToKoreanMonth, koreanMonthToDate } from "~/utils/date";
 
-function EmptyNoticeBox({
+function EmptyMessageBox({
   children,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
@@ -69,25 +69,25 @@ export const loader: LoaderFunction = async ({ request }) => {
   const month = url.searchParams.get("month");
 
   if (month !== null) {
-    const notices = await getSharedNotices({
+    const messages = await getSharedMessages({
       monthStr: month,
       partnerName: partnerName,
     });
     return json({
       monthStr: month,
-      notices: notices,
+      messages: messages,
       partnerName: partnerName,
     });
   } else {
     const todayMonth = dateToKoreanMonth(new Date());
-    const notices = await getSharedNotices({
+    const messages = await getSharedMessages({
       monthStr: todayMonth,
       partnerName: partnerName,
     });
-    // console.log(notices);
+    // console.log(messages);
     return json({
       monthStr: todayMonth,
-      notices: notices,
+      messages: messages,
       partnerName: partnerName,
     });
   }
@@ -101,7 +101,7 @@ export const action: ActionFunction = async ({ request }) => {
     const month = body.get("month")?.toString();
     const reply = body.get("reply")?.toString();
     if (id !== undefined && month !== undefined && reply !== undefined) {
-      const result = await replyNotice({
+      const result = await replyMessage({
         monthStr: month,
         id: id,
         reply: reply,
@@ -126,7 +126,7 @@ export const action: ActionFunction = async ({ request }) => {
       month !== undefined &&
       partnerName !== undefined
     ) {
-      const result = await addNotice({
+      const result = await addMessage({
         partnerName: partnerName,
         monthStr: month,
         topic: topic,
@@ -153,7 +153,7 @@ export default function PartnerAlert() {
   const [selectedDate, setSelectedDate] = useState<Date>(); // 선택중인 날짜 (현재 조회된 월이 아닌, MonthSelectPopover로 선택중인 날짜)
   const [selectedMonthStr, setSelectedMonthStr] = useState<string>(); //선택중인 날짜의 string (XX년 XX월)
 
-  const [isNewNoticeModalOpened, setIsNewNoticeModalOpened] =
+  const [isNewMessageModalOpened, setIsNewMessageModalOpened] =
     useState<boolean>(false);
 
   const [noticeModalStr, setNoticeModalStr] = useState<string>(""); //안내 모달창에서 뜨는 메세지
@@ -226,9 +226,9 @@ export default function PartnerAlert() {
 
       {/* 메세지 추가 모달 */}
       <BasicModal
-        opened={isNewNoticeModalOpened}
+        opened={isNewMessageModalOpened}
         onClose={() => {
-          setIsNewNoticeModalOpened(false);
+          setIsNewMessageModalOpened(false);
         }}
       >
         <div
@@ -265,7 +265,7 @@ export default function PartnerAlert() {
           </div>
           <div style={{ height: "20px" }} />
           <div style={{ display: "flex", justifyContent: "center" }}>
-            <ModalButton onClick={() => setIsNewNoticeModalOpened(false)}>
+            <ModalButton onClick={() => setIsNewMessageModalOpened(false)}>
               취소
             </ModalButton>
             <ModalButton
@@ -278,7 +278,7 @@ export default function PartnerAlert() {
                 formData.set("detail", detailEdit);
                 formData.set("action", "add");
                 submit(formData, { method: "post" });
-                setIsNewNoticeModalOpened(false);
+                setIsNewMessageModalOpened(false);
               }}
             >
               생성
@@ -312,19 +312,19 @@ export default function PartnerAlert() {
               monthStr={selectedMonthStr ?? ""}
             />
             <Space w={20} />
-            <Link to={`/partner/alert?month=${selectedMonthStr}`}>
+            <Link to={`/partner/message?month=${selectedMonthStr}`}>
               <CommonButton>조회하기</CommonButton>
             </Link>
             <Space w={20} />
-            <CommonButton onClick={() => setIsNewNoticeModalOpened(true)}>
+            <CommonButton onClick={() => setIsNewMessageModalOpened(true)}>
               신규 생성
             </CommonButton>
           </div>
         </div>
         <div style={{ height: "20px" }} />
-        {loaderData.notices != undefined && loaderData.notices.length > 0 ? (
+        {loaderData.messages != undefined && loaderData.messages.length > 0 ? (
           <>
-            {UnrepliedNoticeItems(loaderData.notices, monthStr)}
+            {UnrepliedMessageItems(loaderData.messages, monthStr)}
             <div
               style={{
                 backgroundColor: "#D9D9D9",
@@ -337,10 +337,10 @@ export default function PartnerAlert() {
             >
               회신한 일람
             </div>
-            {RepliedNoticeItems(loaderData.notices, monthStr)}
+            {RepliedMessageItems(loaderData.messages, monthStr)}
           </>
         ) : (
-          <EmptyNoticeBox>공유된 알림이 없습니다.</EmptyNoticeBox>
+          <EmptyMessageBox>공유된 쪽지가 없습니다.</EmptyMessageBox>
         )}
 
         <div style={{ minHeight: "70px" }} />
@@ -349,16 +349,16 @@ export default function PartnerAlert() {
   );
 }
 
-function UnrepliedNoticeItems(noticeItems: NoticeItem[], monthStr: string) {
-  return noticeItems.map((item: NoticeItem, index: number) => {
+function UnrepliedMessageItems(messageItems: MessageItem[], monthStr: string) {
+  return messageItems.map((item: MessageItem, index: number) => {
     const replies = item.replies;
     if (replies.length > 0) {
       return null;
     } else {
       return (
-        <PartnerNotice
-          noticeItem={item}
-          key={`NoticeItem_${index}`}
+        <PartnerMessage
+          messageItem={item}
+          key={`MessageItem_${index}`}
           monthStr={monthStr}
         />
       );
@@ -366,16 +366,16 @@ function UnrepliedNoticeItems(noticeItems: NoticeItem[], monthStr: string) {
   });
 }
 
-function RepliedNoticeItems(noticeItems: NoticeItem[], monthStr: string) {
-  return noticeItems.map((item: NoticeItem, index: number) => {
+function RepliedMessageItems(messageItems: MessageItem[], monthStr: string) {
+  return messageItems.map((item: MessageItem, index: number) => {
     const replies = item.replies;
     if (replies.length == 0) {
       return null;
     } else {
       return (
-        <PartnerNotice
-          noticeItem={item}
-          key={`NoticeItem_${index}`}
+        <PartnerMessage
+          messageItem={item}
+          key={`MessageItem_${index}`}
           monthStr={monthStr}
         />
       );

--- a/app/services/firebase/firebase-debug.server.ts
+++ b/app/services/firebase/firebase-debug.server.ts
@@ -6,6 +6,7 @@ import {
   doc,
   getDocs,
   query,
+  setDoc,
   updateDoc,
   where,
 } from "firebase/firestore";
@@ -287,5 +288,48 @@ export async function debug_fixRevenueDataProviderName(
     console.log("All test revenue data editted successfully.");
   } catch (error) {
     console.error("Error editting test revenue data:", error);
+  }
+}
+
+export async function debug_changeNoticeToMessage() {
+  try {
+    const year = 24;
+
+    for (let month = 1; month <= 9; month++) {
+      const monthStr = month.toString().padStart(2, "0"); // '01', '02', ..., '12'
+
+      await setDoc(doc(firestore, "messages", `${year}년 ${monthStr}월`), {
+        isShared: true,
+      });
+
+      const noticeItemsCollectionRef = collection(
+        firestore,
+        "notices",
+        `${year}년 ${monthStr}월`,
+        "items"
+      );
+
+      const itemsSnap = await getDocs(noticeItemsCollectionRef);
+
+      itemsSnap.docs.forEach(async (item) => {
+        const data = item.data();
+        await setDoc(
+          doc(
+            firestore,
+            "messages",
+            `${year}년 ${monthStr}월`,
+            "items",
+            item.id
+          ),
+          data
+        ).catch((error) => {
+          console.error(`Error updating document ${item.id}: `, error);
+        });
+      });
+    }
+
+    console.log("All items have been updated successfully.");
+  } catch (error) {
+    console.error("Error initializing isDiscounted fields: ", error);
   }
 }

--- a/app/services/firebase/message.server.ts
+++ b/app/services/firebase/message.server.ts
@@ -49,11 +49,11 @@ export async function addMessage({
       const timestamp = Timestamp.fromDate(new Date());
       data.sharedDate = timestamp;
     }
-    await setDoc(doc(firestore, `notices/${monthStr}/items/${docName}`), data);
+    await setDoc(doc(firestore, `messages/${monthStr}/items/${docName}`), data);
 
-    await setDoc(doc(firestore, `notices/${monthStr}`), { isShared: "true" });
+    await setDoc(doc(firestore, `messages/${monthStr}`), { isShared: "true" });
 
-    addLog("addNotice", data);
+    addLog("addMessage", data);
 
     return true;
   } catch (error: any) {
@@ -88,8 +88,8 @@ export async function editMessage({
       detail: detail,
       isShared: false,
     };
-    await setDoc(doc(firestore, `notices/${monthStr}/items/${id}`), data);
-    addLog("editNotice", { id: id, ...data });
+    await setDoc(doc(firestore, `messages/${monthStr}/items/${id}`), data);
+    addLog("editMessage", { id: id, ...data });
     return true;
   } catch (error: any) {
     await sendAligoMessage({
@@ -124,7 +124,7 @@ export async function shareMessage({
       isShared: true,
       sharedDate: timestamp,
     };
-    await updateDoc(doc(firestore, `notices/${monthStr}/items/${id}`), data);
+    await updateDoc(doc(firestore, `messages/${monthStr}/items/${id}`), data);
 
     const profile = await getPartnerProfile({ name: partnerName });
     const phone = profile?.phone ?? "";
@@ -137,7 +137,7 @@ export async function shareMessage({
         throw Error(`ALIGO 오류: ${response.message}`);
       }
     }
-    await addLog("shareNotice", { id: id, ...data });
+    await addLog("shareMessage", { id: id, ...data });
     return true;
   } catch (error: any) {
     await sendAligoMessage({
@@ -152,7 +152,7 @@ export async function shareMessage({
  * 쪽지들을 불러옵니다
  * @param month: 월, partnerName: 파트너명 (비어있을 경우 모든 파트너)
  * @returns
- *  List of NoticeItem
+ *  List of MessageItem
  */
 export async function getMessages({
   monthStr: month,
@@ -161,16 +161,16 @@ export async function getMessages({
   monthStr: string;
   partnerName: string;
 }) {
-  const noticesRef = collection(firestore, `notices/${month}/items`);
+  const messagesRef = collection(firestore, `messages/${month}/items`);
   let querySnap;
   if (partnerName.length > 0) {
-    const noticeQuery = query(
-      noticesRef,
+    const messageQuery = query(
+      messagesRef,
       where("partnerName", "==", partnerName)
     );
-    querySnap = await getDocs(noticeQuery);
+    querySnap = await getDocs(messageQuery);
   } else {
-    querySnap = await getDocs(noticesRef);
+    querySnap = await getDocs(messagesRef);
   }
 
   const list: MessageItem[] = [];
@@ -198,7 +198,7 @@ export async function getMessages({
  * 공유된 쪽지들에 한하여 불러옵니다 (파트너 전용)
  * @param month: 월, partnerName: 파트너명
  * @returns
- *  List of NoticeItem
+ *  List of MessageItem
  */
 export async function getSharedMessages({
   monthStr: month,
@@ -207,14 +207,14 @@ export async function getSharedMessages({
   monthStr: string;
   partnerName: string;
 }) {
-  const noticesRef = collection(firestore, `notices/${month}/items`);
+  const messagesRef = collection(firestore, `messages/${month}/items`);
   let querySnap;
-  const noticeQuery = query(
-    noticesRef,
+  const messageQuery = query(
+    messagesRef,
     where("partnerName", "==", partnerName),
     where("isShared", "==", true)
   );
-  querySnap = await getDocs(noticeQuery);
+  querySnap = await getDocs(messageQuery);
 
   const list: MessageItem[] = [];
   querySnap.docs.forEach((doc) => {
@@ -250,12 +250,12 @@ export async function deleteMessage({
   id: string;
 }) {
   try {
-    await deleteDoc(doc(firestore, `notices/${monthStr}/items/${id}`)).catch(
+    await deleteDoc(doc(firestore, `messages/${monthStr}/items/${id}`)).catch(
       (error) => {
         return error.message;
       }
     );
-    addLog("deleteNotice", { monthStr: monthStr, id: id });
+    addLog("deleteMessage", { monthStr: monthStr, id: id });
     return true;
   } catch (error: any) {
     await sendAligoMessage({
@@ -296,9 +296,9 @@ export async function replyMessage({
     const data = {
       replies: arrayUnion(replyStr),
     };
-    await updateDoc(doc(firestore, `notices/${monthStr}/items/${id}`), data);
+    await updateDoc(doc(firestore, `messages/${monthStr}/items/${id}`), data);
 
-    addLog("replyNotice", { monthStr: monthStr, id: id, ...data });
+    addLog("replyMessage", { monthStr: monthStr, id: id, ...data });
 
     return true;
   } catch (error: any) {

--- a/app/services/firebase/message.server.ts
+++ b/app/services/firebase/message.server.ts
@@ -14,16 +14,16 @@ import { sendAligoMessage } from "../aligo.server";
 import { addLog, getPartnerProfile } from "./firebase.server";
 import { firestore } from "./firebaseInit.server";
 import { dateToDayStr, getTimezoneDate } from "~/utils/date";
-import { NoticeItem } from "~/components/notice";
+import { MessageItem } from "~/components/message";
 
 /**
- * 알림을 추가합니다
+ * 쪽지를 추가합니다
  * @param month: 월, partnerName: 파트너명, detail: 상세 내용, topic: 공유주제
  * @returns
  * 성공하면 true 실패시 error message
  *
  */
-export async function addNotice({
+export async function addMessage({
   partnerName,
   topic,
   detail,
@@ -62,13 +62,13 @@ export async function addNotice({
 }
 
 /**
- * 알림을 수정합니다.
+ * 쪽지를 수정합니다.
  * @param month: 월, partnerName: 파트너명, detail: 상세 내용, topic: 공유주제, id: 해당 doc id
  * @returns
  * 성공하면 true 실패시 error message
  *
  */
-export async function editNotice({
+export async function editMessage({
   partnerName,
   topic,
   detail,
@@ -101,13 +101,13 @@ export async function editNotice({
 }
 
 /**
- * 알림을 공유합니다..
+ * 쪽지를 공유합니다.
  * @param month: 월, id: 해당 doc id
  * @returns
  * 성공하면 true 실패시 error message
  *
  */
-export async function shareNotice({
+export async function shareMessage({
   monthStr,
   id,
   partnerName,
@@ -130,7 +130,7 @@ export async function shareNotice({
     const phone = profile?.phone ?? "";
     if (phone.length > 0) {
       const response = await sendAligoMessage({
-        text: `[로파파트너] [${topic}]에 대하여 긴급알림이 있습니다. 파트너사이트의 '발신함 / 수신함'을 확인 부탁드립니다.`,
+        text: `[로파파트너] [${topic}]에 대하여 긴급알림이 있습니다. 파트너사이트의 '쪽지함'을 확인 부탁드립니다.`,
         receiver: phone,
       });
       if (response.result_code != 1) {
@@ -149,12 +149,12 @@ export async function shareNotice({
 }
 
 /**
- * 알림들을 불러옵니다
+ * 쪽지들을 불러옵니다
  * @param month: 월, partnerName: 파트너명 (비어있을 경우 모든 파트너)
  * @returns
  *  List of NoticeItem
  */
-export async function getNotices({
+export async function getMessages({
   monthStr: month,
   partnerName,
 }: {
@@ -173,7 +173,7 @@ export async function getNotices({
     querySnap = await getDocs(noticesRef);
   }
 
-  const list: NoticeItem[] = [];
+  const list: MessageItem[] = [];
   querySnap.docs.forEach((doc) => {
     const data = doc.data();
     const timestamp: Timestamp | undefined = data.sharedDate;
@@ -195,12 +195,12 @@ export async function getNotices({
 }
 
 /**
- * 공유된 알림들에 한하여 불러옵니다 (파트너 전용)
+ * 공유된 쪽지들에 한하여 불러옵니다 (파트너 전용)
  * @param month: 월, partnerName: 파트너명
  * @returns
  *  List of NoticeItem
  */
-export async function getSharedNotices({
+export async function getSharedMessages({
   monthStr: month,
   partnerName,
 }: {
@@ -216,7 +216,7 @@ export async function getSharedNotices({
   );
   querySnap = await getDocs(noticeQuery);
 
-  const list: NoticeItem[] = [];
+  const list: MessageItem[] = [];
   querySnap.docs.forEach((doc) => {
     const data = doc.data();
     const timestamp: Timestamp | undefined = data.sharedDate;
@@ -238,11 +238,11 @@ export async function getSharedNotices({
 }
 
 /**
- * 알림을 삭제합니다.
- * @param month: 월, id: 삭제할 알림 문서 아이디
+ * 쪽지를 삭제합니다.
+ * @param month: 월, id: 삭제할 쪽지 문서 아이디
  * @returns
  */
-export async function deleteNotice({
+export async function deleteMessage({
   monthStr,
   id,
 }: {
@@ -267,13 +267,13 @@ export async function deleteNotice({
 }
 
 /**
- * 알림에 대해 답신합니다.
+ * 쪽지에 대해 답신합니다.
  * @param month: 월, id: 해당 doc id, reply: 답신
  * @returns
  * 성공하면 true 실패시 error message
  *
  */
-export async function replyNotice({
+export async function replyMessage({
   monthStr,
   id,
   reply,


### PR DESCRIPTION
- 기존 발신함/수신함으로 이름지어졌던 페이지의 이름 및 관련 함수/기능들의 이름을 쪽지로 변경하였습니다.
(기존에는 어드민쪽에서 협력사로 보내는 공지 느낌이였으나, 이제 협력사들도 어드민쪽에 메세지를 먼저 보낼 수 있게 되며 기능에 더 알맞게 이름 변경)