### PR TITLE
fix: 주문상태가 배송이 아니여도 통계에 반영

### DIFF
--- a/app/components/revenue_data.tsx
+++ b/app/components/revenue_data.tsx
@@ -270,7 +270,6 @@ export function getDiscountedPrice(item: RevenueData) {
 //매출
 export function getSalesAmount(item: RevenueData) {
   const isCsOk = item.cs == "정상";
-  const isOrderStatusDeliver = item.orderStatus == "배송";
   const salesPrice = item.isDiscounted
     ? (item.price *
         (100 -
@@ -280,7 +279,7 @@ export function getSalesAmount(item: RevenueData) {
       100
     : item.price;
 
-  return isCsOk && isOrderStatusDeliver ? salesPrice * item.amount : 0;
+  return isCsOk ? salesPrice * item.amount : 0;
 }
 
 export function getPartnerSettlement(item: RevenueData) {
@@ -337,8 +336,7 @@ export function getProceeds(item: RevenueData) {
     return NaN;
   }
   const isCsOK = item.cs == "정상";
-  const isOrderStatusDeliver = item.orderStatus == "배송";
-  if (!isCsOK || !isOrderStatusDeliver) {
+  if (!isCsOK) {
     return 0;
   }
   const isLofa = LofaSellers.includes(item.seller);
@@ -433,10 +431,6 @@ function RevenueDataItem({
     return item.cs == "정상";
   }, [item]);
 
-  const isOrderStatusDeliver = useMemo(() => {
-    return item.orderStatus == "배송";
-  }, [item]);
-
   const discountedPrice = useMemo(() => {
     return item.isDiscounted
       ? (item.price *
@@ -449,13 +443,11 @@ function RevenueDataItem({
   }, [item.isDiscounted]);
 
   const totalSalesAmount = useMemo(() => {
-    return isCsOK && isOrderStatusDeliver
-      ? (discountedPrice ?? item.price) * item.amount
-      : 0;
+    return isCsOK ? (discountedPrice ?? item.price) * item.amount : 0;
   }, [item]);
 
   const normalPriceTotalSalesAmount = useMemo(() => {
-    return isCsOK && isOrderStatusDeliver ? item.price * item.amount : 0;
+    return isCsOK ? item.price * item.amount : 0;
   }, [item]);
 
   const businessTaxStandard = useMemo(() => {

--- a/app/routes/admin/revenue-chart.tsx
+++ b/app/routes/admin/revenue-chart.tsx
@@ -600,8 +600,7 @@ export default function Page() {
         const currentAmount = productMap.get(item.productName) || 0;
 
         const isCsOk = item.cs == "정상";
-        const isOrderStatusDeliver = item.orderStatus == "배송";
-        if (isCsOk && isOrderStatusDeliver) {
+        if (isCsOk) {
           productMap.set(item.productName, currentAmount + item.amount);
         }
 
@@ -808,8 +807,7 @@ export default function Page() {
     data.forEach((item) => {
       const existingAmount = productAmountMap.get(item.productName) || 0;
       const isCsOk = item.cs == "정상";
-      const isOrderStatusDeliver = item.orderStatus == "배송";
-      if (isCsOk && isOrderStatusDeliver) {
+      if (isCsOk) {
         productAmountMap.set(item.productName, existingAmount + item.amount);
       }
     });

--- a/app/routes/admin/revenue-db.tsx
+++ b/app/routes/admin/revenue-db.tsx
@@ -296,7 +296,8 @@ export default function Page() {
   const [startDate, setStartDate] = useState<Date>(); //주문일 시작
   const [endDate, setEndDate] = useState<Date>(); //주문일 종료
   const [seller, setSeller] = useState<string>(searchedSeller); // 판매처
-  const [providerName, setProviderName] = useState<string>(searchedProviderName); // 공급처
+  const [providerName, setProviderName] =
+    useState<string>(searchedProviderName); // 공급처
   const [productName, setProductName] = useState<string>(searchedProductName); //상품명
   const [cs, setCs] = useState<string | null>(searchedCs); //CS
   const [orderStatus, setOrderStatus] = useState<string | null>(
@@ -583,7 +584,7 @@ export default function Page() {
       type: Number,
       value: (data: RevenueData) => {
         if (data.isDiscounted) {
-          if (data.cs == "정상" && data.orderStatus == "배송") {
+          if (data.cs == "정상") {
             return (
               (data.price * data.amount * data.lofaDiscountLevyRate!) / 100
             );

--- a/app/services/firebase/revenueData.server.ts
+++ b/app/services/firebase/revenueData.server.ts
@@ -292,7 +292,6 @@ export async function getRevenueStats({
       const data = doc.data() as RevenueData;
       const isLofa = LofaSellers.includes(data.seller);
       const isCsOK = data.cs == "정상";
-      const isOrderStatusDeliver = data.orderStatus == "배송";
 
       const partnerProfile: PartnerProfile = partnerProfiles.get(
         data.providerName
@@ -330,14 +329,8 @@ export async function getRevenueStats({
       let platformSettlement;
 
       if (!data.isDiscounted) {
-        lofaSalesAmount =
-          isCsOK && isLofa && isOrderStatusDeliver
-            ? data.price * data.amount
-            : 0;
-        otherSalesAmount =
-          isCsOK && !isLofa && isOrderStatusDeliver
-            ? data.price * data.amount
-            : 0;
+        lofaSalesAmount = isCsOK && isLofa ? data.price * data.amount : 0;
+        otherSalesAmount = isCsOK && !isLofa ? data.price * data.amount : 0;
         totalSalesAmount = lofaSalesAmount + otherSalesAmount;
         partnerSettlement =
           (totalSalesAmount * (100 - (data.commonFeeRate ?? NaN))) / 100;
@@ -346,7 +339,7 @@ export async function getRevenueStats({
           : (totalSalesAmount * (100 - (data.platformFeeRate ?? NaN))) / 100; //플랫폼정산금
         platformFee = totalSalesAmount - platformSettlement;
         lofaDiscountLevy = 0;
-        if (!isCsOK || !isOrderStatusDeliver) {
+        if (!isCsOK) {
           netProfitAfterTax = 0;
         }
       } else {
@@ -367,11 +360,11 @@ export async function getRevenueStats({
           data.partnerDiscountLevyRate +
           data.platformDiscountLevyRate;
         lofaSalesAmount =
-          isCsOK && isLofa && isOrderStatusDeliver
+          isCsOK && isLofa
             ? ((data.price * (100 - totalDiscountRate)) / 100.0) * data.amount
             : 0;
         otherSalesAmount =
-          isCsOK && !isLofa && isOrderStatusDeliver
+          isCsOK && !isLofa
             ? ((data.price * (100 - totalDiscountRate)) / 100.0) * data.amount
             : 0;
         totalSalesAmount = lofaSalesAmount + otherSalesAmount;


### PR DESCRIPTION
요청사항: 

1. 수익통계에 반영되는 주문이 상태-배송, cs-정상 주문들만 반영되도록 해달라고 했는데요. 상태는 상관없이 cs-정상 이면 수익통계에 반영되도록 변경 부탁드려요.