### PR TITLE
fix: 공급처명, 상품분류가 파트너 계정에선 보이지 않게

### DIFF
--- a/app/components/partner_profile.tsx
+++ b/app/components/partner_profile.tsx
@@ -366,18 +366,27 @@ export function PartnerProfile({
                 {partnerProfile.businessTaxStandard}
               </div>
             </ProfileGridItem>
-            <ProfileGridItem isMobile={isMobileMemo}>
-              <div style={{ padding: "13px", width: "120px" }}>공급처명</div>
-              <div style={{ padding: "13px" }}>
-                {partnerProfile.providerName ?? partnerProfile.name}
-              </div>
-            </ProfileGridItem>
-            <ProfileGridItem isMobile={isMobileMemo}>
-              <div style={{ padding: "13px", width: "120px" }}>상품분류</div>
-              {partnerProfile.productCategory?.map((val) => (
-                <ProductCategoryItem item={val} />
-              )) ?? <></>}
-            </ProfileGridItem>
+            {isPartner ? (
+              <></>
+            ) : (
+              <ProfileGridItem isMobile={isMobileMemo}>
+                <div style={{ padding: "13px", width: "120px" }}>공급처명</div>
+                <div style={{ padding: "13px" }}>
+                  {partnerProfile.providerName ?? partnerProfile.name}
+                </div>
+              </ProfileGridItem>
+            )}
+
+            {isPartner ? (
+              <></>
+            ) : (
+              <ProfileGridItem isMobile={isMobileMemo}>
+                <div style={{ padding: "13px", width: "120px" }}>상품분류</div>
+                {partnerProfile.productCategory?.map((val) => (
+                  <ProductCategoryItem item={val} />
+                )) ?? <></>}
+              </ProfileGridItem>
+            )}
           </ProfileGridContainer>
         </PartnerProfileBox>
       </>


### PR DESCRIPTION
요청사항:

3. 업체계정으로 들어가보니, 계약업체목록에서 조회되는 모든 정보를 같이 보게 되는것 같더라구요.
공급처명과 상품분류 라벨넣는것은 안보이도록 부탁드려요.
