### PR TITLE
feature: 수익 통계에  카테고리, 원가 항목 추가

### DIFF
--- a/app/components/seller.tsx
+++ b/app/components/seller.tsx
@@ -13,6 +13,7 @@ export const PossibleSellers = [
   "오늘의집",
   "카카오",
   "무신사",
+  "광주비엔날레"
 ];
 
 export const LofaSellers = ["로파공홈", "용산쇼룸", "예약거래"];
@@ -73,6 +74,7 @@ export function SellerSelect({
         { value: "카카오", label: "카카오" },
         { value: "무신사", label: "무신사" },
         { value: "예약거래", label: "예약거래" },
+        { value: "광주비엔날레", label: "광주비엔날레" },
         { value: "etc", label: "기타" },
       ]}
       styles={{

--- a/app/routes/admin/revenue-db.tsx
+++ b/app/routes/admin/revenue-db.tsx
@@ -350,6 +350,8 @@ export default function Page() {
   const [isShowingNetProfitAfterTax, setIsShowingNetProfitAfterTax] =
     useState<boolean>(true);
   const [isShowingReturnRate, setIsShowingReturnRate] = useState<boolean>(true);
+  const [isShowingCategory, setIsShowingCategory] = useState<boolean>(true);
+  const [isShowingCost, setIsShowingCost] = useState<boolean>(true);
 
   const [isShowingShowing, setIsShowingShowing] = useState<boolean>(false);
 
@@ -558,6 +560,20 @@ export default function Page() {
       column: "CS",
       type: String,
       value: (data: RevenueData) => data.cs,
+      width: 20,
+      wrap: true,
+    },
+    {
+      column: "카테고리",
+      type: String,
+      value: (data: RevenueData) => data.category,
+      width: 20,
+      wrap: true,
+    },
+    {
+      column: "원가",
+      type: Number,
+      value: (data: RevenueData) => data.cost,
       width: 20,
       wrap: true,
     },
@@ -1077,6 +1093,28 @@ export default function Page() {
               }}
             />
             <Space w={20} />
+            <div>카테고리</div>
+            <Space w={10} />
+            <Checkbox
+              color={"gray"}
+              size={"xs"}
+              checked={isShowingCategory}
+              onChange={(event) => {
+                setIsShowingCategory(event.currentTarget.checked);
+              }}
+            />
+            <Space w={20} />
+            <div>원가</div>
+            <Space w={10} />
+            <Checkbox
+              color={"gray"}
+              size={"xs"}
+              checked={isShowingCost}
+              onChange={(event) => {
+                setIsShowingCost(event.currentTarget.checked);
+              }}
+            />
+            <Space w={20} />
             <div>업체정산금</div>
             <Space w={10} />
             <Checkbox
@@ -1177,6 +1215,8 @@ export default function Page() {
             showingProceeds: isShowingProceeds,
             showingNetProfitAfterTax: isShowingNetProfitAfterTax,
             showingReturnRate: isShowingReturnRate,
+            showingCategory: isShowingCategory,
+            showingCost: isShowingCost,
           }}
         />
       ) : (

--- a/app/routes/admin/revenue-file-upload.tsx
+++ b/app/routes/admin/revenue-file-upload.tsx
@@ -247,6 +247,8 @@ export default function Page() {
             orderStatus: element.상태?.toString(),
             cs: element["CS"]?.toString(),
             isDiscounted: false,
+            category: element.카테고리?.toString(),
+            cost: Number(element.원가),
           };
 
           const result = checkRevenueDataItem(item);


### PR DESCRIPTION
요청사항:

- 수익통계내역에 '카테고리', '원가' 항목 추가
- '카테고리'는 위탁, 사입, 제조 중 하나가 가능하며, 사입/제조일 경우, 업체정산금이 원가*개수로 고정됨.
- 수익통계내역에 항목이 추가됨에 따라 통계용 파일 업로드, 정산통계DB 페이지에 해당 항목이 표에 추가됨. 

- 그외 수정사항: 별도로 계산이 이루어지던 일부 수익통계식을 revenue_data.tsx의 getXXXX 함수로 통일되어 계산되도록 교체