### PR TITLE
fix: add 광주비엔날레 seller to NormalPriceStandardSellers

### DIFF
--- a/app/components/seller.tsx
+++ b/app/components/seller.tsx
@@ -25,6 +25,7 @@ export const NormalPriceStandardSellers = [
   "로파공홈",
   "용산쇼룸",
   "예약거래",
+  "광주비엔날레"
 ];
 
 /**


### PR DESCRIPTION
- 판매처 광주비엔날레에 대한 플랫폼수수료를 정상판매가 기준으로 