### PR TITLE
feature: 파트너수수료 분류에 '광주비엔날레' 추가

### DIFF
--- a/app/components/partner_profile.tsx
+++ b/app/components/partner_profile.tsx
@@ -13,6 +13,7 @@ export type PartnerProfile = {
   email: string;
   phone: string;
   lofaFee: number;
+  gwangjuBiennaleFee: number;
   otherFee: number;
   shippingFee: number;
   brn: string;
@@ -175,6 +176,9 @@ export function PartnerProfile({
   const [phoneEdit, setPhoneEdit] = useState(partnerProfile.phone);
   const [lofaFeeEdit, setLofaFeeEdit] = useState(partnerProfile.lofaFee);
   const [otherFeeEdit, setOtherFeeEdit] = useState(partnerProfile.otherFee);
+  const [gwangjuBiennaleFeeEdit, setGwangjuBiennaleFeeEdit] = useState(
+    partnerProfile.gwangjuBiennaleFee
+  );
   const [shippingFeeEdit, setShippingFeeEdit] = useState(
     partnerProfile.shippingFee
   );
@@ -328,7 +332,11 @@ export function PartnerProfile({
               >
                 <div style={{ fontSize: "12px" }}>로파 공홈 및 쇼룸</div>
                 <div style={{ padding: "13px" }}>{partnerProfile.lofaFee}%</div>
-                <div style={{ fontSize: "12px" }}>타 채널</div>
+                <div style={{ fontSize: "12px" }}>광주비엔날레</div>
+                <div style={{ padding: "13px" }}>
+                  {partnerProfile.gwangjuBiennaleFee}%
+                </div>
+                <div style={{ fontSize: "12px" }}>기타 채널</div>
                 <div style={{ padding: "13px" }}>
                   {partnerProfile.otherFee}%
                 </div>
@@ -498,7 +506,19 @@ export function PartnerProfile({
                   style={{ width: "50px" }}
                 />
                 <Space w={10} />
-                <div style={{ fontSize: "15px" }}>타 채널</div>
+                <div style={{ fontSize: "15px" }}>광주비엔날레</div>
+                <InputBox
+                  type="number"
+                  name="gwangjuBiennaleFee"
+                  value={gwangjuBiennaleFeeEdit}
+                  onChange={(e) =>
+                    setGwangjuBiennaleFeeEdit(Number(e.target.value))
+                  }
+                  required
+                  style={{ width: "50px" }}
+                />
+                <Space w={10} />
+                <div style={{ fontSize: "15px" }}>기타 채널</div>
                 <InputBox
                   type="number"
                   name="otherFee"

--- a/app/components/settlement_table.tsx
+++ b/app/components/settlement_table.tsx
@@ -262,6 +262,8 @@ export function setSettlementFee(
   }
   if (LofaSellers.includes(item.seller)) {
     item.fee = partnerProfile.lofaFee;
+  } else if(item.seller == "광주비엔날레"){
+    item.fee = partnerProfile.gwangjuBiennaleFee;
   } else {
     item.fee = partnerProfile.otherFee;
   }

--- a/app/routes/admin/debug.tsx
+++ b/app/routes/admin/debug.tsx
@@ -3,9 +3,10 @@ import { useSubmit } from "@remix-run/react";
 import { useRef } from "react";
 import {
   debug_addExtraDataToRevenueDB,
+  debug_addGwangjuBiennaleFee,
   debug_changeNoticeToMessage,
   debug_changePartnerNameToProviderName,
-} from "~/services/firebase/firebase-debug.server";
+} from "~/services/firebase/debug.server";
 
 export const action: ActionFunction = async ({ request }) => {
   console.log("request submitted");
@@ -14,7 +15,7 @@ export const action: ActionFunction = async ({ request }) => {
   // await debug_fixRevenueDataProviderName("LOFA ORIGINAL", "로파오리지널");
   //await debug_addExtraDataToRevenueDB();
   // await debug_changeNoticeToMessage();\
-  await debug_changePartnerNameToProviderName();
+  await debug_addGwangjuBiennaleFee();
   return null;
 };
 

--- a/app/routes/admin/partner-list.tsx
+++ b/app/routes/admin/partner-list.tsx
@@ -50,6 +50,7 @@ export const action: ActionFunction = async ({ request }) => {
     const phone = body.get("phone")?.toString();
     const lofaFee = Number(body.get("lofaFee"));
     const otherFee = Number(body.get("otherFee"));
+    const gwangjuBiennaleFee = Number(body.get("gwangjuBiennaleFee"));
     const shippingFee = Number(body.get("shippingFee"));
     const brn = body.get("brn")?.toString();
     const bankAccount = body.get("bankAccount")?.toString();
@@ -78,6 +79,7 @@ export const action: ActionFunction = async ({ request }) => {
         phone: phone,
         lofaFee: lofaFee,
         otherFee: otherFee,
+        gwangjuBiennaleFee: gwangjuBiennaleFee,
         shippingFee: shippingFee,
         brn: brn ?? "",
         bankAccount: bankAccount ?? "",
@@ -170,6 +172,7 @@ export default function AdminPartnerList() {
             phone: "",
             lofaFee: 0,
             otherFee: 0,
+            gwangjuBiennaleFee: 0,
             shippingFee: 0,
             brn: "",
             bankAccount: "",
@@ -198,6 +201,7 @@ export default function AdminPartnerList() {
               phone: doc.phone,
               lofaFee: doc.lofaFee,
               otherFee: doc.otherFee,
+              gwangjuBiennaleFee: doc.gwangjuBiennaleFee,
               shippingFee: doc.shippingFee,
               brn: doc.brn,
               bankAccount: doc.bankAccount,
@@ -270,7 +274,13 @@ const schema = [
     width: 20,
   },
   {
-    column: "외부채널 수수료",
+    column: "광주비엔날레 수수료",
+    type: Number,
+    value: (profile: PartnerProfile) => profile.gwangjuBiennaleFee,
+    width: 20,
+  },
+  {
+    column: "기타채널 수수료",
     type: Number,
     value: (profile: PartnerProfile) => profile.otherFee,
     width: 20,

--- a/app/routes/partner/my-info.tsx
+++ b/app/routes/partner/my-info.tsx
@@ -45,6 +45,7 @@ export default function AdminPartnerList() {
             phone: loaderData.phone,
             lofaFee: loaderData.lofaFee,
             otherFee: loaderData.otherFee,
+            gwangjuBiennaleFee: loaderData.gwangjuBiennaleFee,
             shippingFee: loaderData.shippingFee,
             brn: loaderData.brn,
             bankAccount: loaderData.bankAccount,

--- a/app/services/firebase/debug.server.ts
+++ b/app/services/firebase/debug.server.ts
@@ -111,6 +111,21 @@ export async function debug_fixPartnerProfileTaxStandard() {
   });
 }
 
+export async function debug_addGwangjuBiennaleFee() {
+  const accountsRef = collection(firestore, "accounts");
+  const querySnap = await getDocs(accountsRef);
+  querySnap.docs.forEach(async (item) => {
+    const data = item.data();
+    if (!data.gwangjuBiennaleFee) {
+      await updateDoc(doc(firestore, "accounts", data.name), {
+        gwangjuBiennaleFee: 38,
+      }).catch((error) => {
+        return error.message;
+      });
+    }
+  });
+}
+
 export async function debug_fixPartnerProviderNameStandard() {
   const accountsRef = collection(firestore, "accounts");
   const querySnap = await getDocs(accountsRef);

--- a/app/services/firebase/firebase.server.ts
+++ b/app/services/firebase/firebase.server.ts
@@ -183,6 +183,7 @@ export async function addPartnerProfile({
     phone: partnerProfile.phone,
     lofaFee: partnerProfile.lofaFee,
     otherFee: partnerProfile.otherFee,
+    gwangjuBiennaleFee: partnerProfile.gwangjuBiennaleFee, 
     shippingFee: partnerProfile.shippingFee,
     brn: partnerProfile.brn,
     bankAccount: partnerProfile.bankAccount,


### PR DESCRIPTION
파트너 프로필의 수수료에 로파채널수수료, 타채널수수료와 더불어 '광주비엔날레수수료' 항목이 추가됩니다. 
판매처가 '광주비엔날레'인경우, 해당 수수료가 정상수수료로 적용됩니다. 

파트너프로필에 해당 항목이 추가로 보이며, 수수료 영역의 '타채널'이라는 명칭은 '기타채널'이라는 명칭으로 수정됩니다. 