### PR TITLE
fix: 할인내역 관리에서 검색되는 쿼리 조건 순서 변경

### DIFF
--- a/app/services/firebase/discount.server.ts
+++ b/app/services/firebase/discount.server.ts
@@ -119,19 +119,45 @@ export async function getDiscountData({
   const discountDataRef = collection(firestore, `discount-db`);
   const isUsingSeller = seller.length > 0 && seller != "all";
   const isUsingProviderName = providerName.length > 0;
-  let discountDataQuery = query(
-    discountDataRef,
-    and(
-      where("startDate", "<=", Timestamp.fromDate(endDate)),
-      where("endDate", ">=", Timestamp.fromDate(startDate)),
-      where("seller", isUsingSeller ? "==" : ">=", isUsingSeller ? seller : ""),
-      where(
-        "providerName",
-        isUsingProviderName ? "==" : ">=",
-        isUsingProviderName ? providerName : ""
+  let discountDataQuery;
+
+  if (isUsingProviderName && isUsingSeller) {
+    discountDataQuery = query(
+      discountDataRef,
+      and(
+        where("providerName", "==", providerName),
+        where("seller", "==", seller),
+        where("startDate", "<=", Timestamp.fromDate(endDate)),
+        where("endDate", ">=", Timestamp.fromDate(startDate))
       )
-    )
-  );
+    );
+  } else if (isUsingProviderName && !isUsingSeller) {
+    discountDataQuery = query(
+      discountDataRef,
+      and(
+        where("providerName", "==", providerName),
+        where("startDate", "<=", Timestamp.fromDate(endDate)),
+        where("endDate", ">=", Timestamp.fromDate(startDate))
+      )
+    );
+  } else if (!isUsingProviderName && isUsingSeller) {
+    discountDataQuery = query(
+      discountDataRef,
+      and(
+        where("startDate", "<=", Timestamp.fromDate(endDate)),
+        where("endDate", ">=", Timestamp.fromDate(startDate)),
+        where("seller", "==", seller)
+      )
+    );
+  } else {
+    discountDataQuery = query(
+      discountDataRef,
+      and(
+        where("startDate", "<=", Timestamp.fromDate(endDate)),
+        where("endDate", ">=", Timestamp.fromDate(startDate))
+      )
+    );
+  }
 
   const querySnap = await getDocs(discountDataQuery);
   const searchResult: { data: DocumentData; id: string }[] = [];


### PR DESCRIPTION
검색 속도 개선을 위해 쿼리 순서를 변경
기존: startDate > endDate > providerName > seller (providerName, seller의 경우 공백일 때 쿼리조건을 ">=", ""로 입력받음)
이후: - providerName, seller 입력되었는지에 따라 조건 추가 여부 변경됨
providerName > endDate > startDate > seller